### PR TITLE
Use postgres 12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 services:
   metadata-db:
-    image: postgres:10.9-alpine
+    image: postgres:12.4-alpine
     restart: always
     environment:
       POSTGRES_PASSWORD: password


### PR DESCRIPTION
We will be using postgres 12 as the RDS instance DB so we should use the same in our docker-compose.