### PR TITLE
Create version api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'tzinfo-data'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'factory_bot_rails'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,11 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.9.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -169,6 +174,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  factory_bot_rails
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.2, >= 6.0.2.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,22 @@
 class ApplicationController < ActionController::API
+  private
+
+  def service_params
+    params.permit(:metadata)
+    attributes = params[:metadata]
+
+    if attributes
+      {
+        name: attributes[:service_name],
+        created_by: attributes[:created_by],
+        metadata_attributes: [{
+          data: attributes,
+          created_by: attributes[:created_by],
+          locale: attributes[:locale] || 'en'
+        }]
+      }
+    else
+      {}
+    end
+  end
 end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -3,7 +3,7 @@ class ServicesController < ApplicationController
     service = Service.new(service_params)
 
     if service.save
-      metadata = service.metadata.last
+      metadata = service.metadata.order(created_at: :desc).first
 
       render json: {
         service_id: service.id,

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -5,13 +5,10 @@ class ServicesController < ApplicationController
     if service.save
       metadata = service.metadata.order(created_at: :desc).first
 
-      render json: {
-        service_id: service.id,
-        service_name: service.name,
-        created_by: service.created_by,
-        version_id: metadata.id,
-        locale: metadata.locale
-      }.merge(metadata.data), status: :created
+      render(
+        json: MetadataSerialiser.new(service, metadata).attributes,
+        status: :created
+      )
     else
       render json: { message: service.errors.full_messages }, status: :unprocessable_entity
     end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,8 +1,8 @@
-class ServicesController < ApplicationController
+class VersionsController < ApplicationController
   def create
-    service = Service.new(service_params)
+    service = Service.find(params[:service_id])
 
-    if service.save
+    if service.update(service_params)
       metadata = service.metadata.last
 
       render json: {
@@ -11,9 +11,10 @@ class ServicesController < ApplicationController
         created_by: service.created_by,
         version_id: metadata.id,
         locale: metadata.locale
-      }.merge(metadata.data), status: :created
+      }.merge(metadata.data), status: :ok
     else
       render json: { message: service.errors.full_messages }, status: :unprocessable_entity
     end
   end
+
 end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -3,7 +3,7 @@ class VersionsController < ApplicationController
     service = Service.find(params[:service_id])
 
     if service.update(service_params)
-      metadata = service.metadata.last
+      metadata = service.metadata.order(created_at: :desc).first
 
       render json: {
         service_id: service.id,

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -5,16 +5,12 @@ class VersionsController < ApplicationController
     if service.update(service_params)
       metadata = service.metadata.order(created_at: :desc).first
 
-      render json: {
-        service_id: service.id,
-        service_name: service.name,
-        created_by: service.created_by,
-        version_id: metadata.id,
-        locale: metadata.locale
-      }.merge(metadata.data), status: :ok
+      render(
+        json: MetadataSerialiser.new(service, metadata).attributes,
+        status: :created
+      )
     else
       render json: { message: service.errors.full_messages }, status: :unprocessable_entity
     end
   end
-
 end

--- a/app/serialisers/metadata_serialiser.rb
+++ b/app/serialisers/metadata_serialiser.rb
@@ -1,0 +1,20 @@
+class MetadataSerialiser
+  include ActiveModel::Serializers::JSON
+
+  attr_accessor :service, :metadata
+
+  def initialize(service, metadata)
+    @service = service
+    @metadata = metadata
+  end
+
+  def attributes
+    {
+      service_id: service.id,
+      service_name: service.name,
+      created_by: service.created_by,
+      version_id: metadata.id,
+      locale: metadata.locale
+    }.merge(metadata.data)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
 
-  resources :services, only: :create
+  resources :services, only: [:create] do
+    resources :versions, only: :create
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :service do
+    name { 'Cowboy Bebop' }
+    created_by  { 'Fay' }
+  end
+end

--- a/spec/fixtures/create_service.json
+++ b/spec/fixtures/create_service.json
@@ -1,0 +1,30 @@
+{
+  "metadata": {
+    "service_name": "Service Name",
+    "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+    "configuration": {
+      "_id": "config.modules",
+      "_type": "config.modules",
+      "modules": [
+        {
+          "_id": "config.module.savereturn",
+          "_type": "config.module",
+          "enabled": "off",
+          "module": "savereturn",
+          "title": "Save and return"
+        }
+      ]
+    },
+    "pages": [
+      {
+        "_id": "page.start",
+        "_type": "page.start",
+        "body": "**This is the main content section of your start page**\r\n\r\n[Edit this page](/edit) with content for your own service.\r\n\r\n## Adding more content\r\n\r\nYou can add multiple headings, links and paragraphs - all in this one content section.\r\n\r\nUse [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format headings, bullet lists and links.",
+        "heading": "This is your start page heading",
+        "lede": "This is your start page first paragraph. You can only have one paragraph here.",
+        "steps": [],
+        "url": "/"
+      }
+    ]
+  }
+}

--- a/spec/fixtures/create_version.json
+++ b/spec/fixtures/create_version.json
@@ -1,0 +1,45 @@
+{
+  "metadata": {
+    "service_name": "Service Name",
+    "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+    "configuration": {
+      "_id": "config.modules",
+      "_type": "config.modules",
+      "modules": [
+        {
+          "_id": "config.module.savereturn",
+          "_type": "config.module",
+          "enabled": "off",
+          "module": "savereturn",
+          "title": "Save and return"
+        }
+      ]
+    },
+    "pages": [
+      {
+        "_id": "page.start",
+        "_type": "page.start",
+        "body": "**This is the main content section of your start page**\r\n\r\n[Edit this page](/edit) with content for your own service.\r\n\r\n## Adding more content\r\n\r\nYou can add multiple headings, links and paragraphs - all in this one content section.\r\n\r\nUse [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format headings, bullet lists and links.",
+        "heading": "This is your start page heading",
+        "lede": "This is your start page first paragraph. You can only have one paragraph here.",
+        "steps": [
+          "page.second-page"
+        ],
+        "url": "/"
+      },
+      {
+        "_id": "page.second-page",
+        "_type": "page.singlequestion",
+        "components": [
+          {
+            "_id": "page.second-page--text.auto_name__1",
+            "_type": "text",
+            "label": "What is your name?",
+            "name": "auto_name__1"
+          }
+        ],
+        "url": "second-page"
+      }
+    ]
+  }
+}

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 

--- a/spec/requests/create_service_spec.rb
+++ b/spec/requests/create_service_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe 'POST /services', type: :request do
   let(:response_body) { JSON.parse(response.body) }
 
   before do
-    post '/services', params: params
+    post '/services', params: params, as: :json
   end
 
   context 'when valid attributes' do

--- a/spec/requests/create_version_spec.rb
+++ b/spec/requests/create_version_spec.rb
@@ -1,0 +1,110 @@
+RSpec.describe 'POST /services/:id/versions' do
+  let(:response_body) { JSON.parse(response.body) }
+  let(:service) { create(:service) }
+
+  before do
+    post "/services/#{service.id}/versions", params: params
+  end
+
+  context 'when valid attributes' do
+    let(:params) do
+      {
+        "metadata": {
+          "service_name": "Service Name",
+          "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+          "configuration": {
+             "_id": "service",
+             "_type": "config.service"
+           },
+          "pages": [
+            {
+              "_id": "page.start",
+              "_type": "page.start",
+              "url": "/"
+            },
+            {
+              "_id": "page.upload-cop1a",
+              "_type": "page.singlequestion",
+              "components": [
+                {
+                  "_id": "page.upload-cop1a--upload.auto_name__1",
+                  "_type": "upload",
+#                  "my_awesome_errors": {},
+                  "hint": "",
+                  "label": "Upload your completed supporting information (COP1A)",
+                  "name": "upload-cop1a"
+                }
+              ],
+              "steps": [
+                "page.upload-cop1a-check"
+              ],
+              "url": "upload-cop1a"
+            },
+          ],
+          "locale": "en"
+        }
+      }
+    end
+
+    it 'returns success status' do
+      expect(response.status).to be(200)
+    end
+
+    it 'returns the metadata' do
+      expected = {
+        "service_id" => service.id,
+        "service_name" => "Service Name",
+        "created_by" => "4634ec01-5618-45ec-a4e2-bb5aa587e751",
+        "configuration" => {
+           "_id" => "service",
+           "_type" => "config.service"
+         },
+        "pages" => [
+          {
+            "_id" => "page.start",
+            "_type" => "page.start",
+            "url" => "/"
+          },
+          {
+            "_id" => "page.upload-cop1a",
+            "_type" => "page.singlequestion",
+            "components" => [
+              {
+                "_id" => "page.upload-cop1a--upload.auto_name__1",
+                "_type" => "upload",
+#                "errors" => {},
+                "hint" => "",
+                "label" => "Upload your completed supporting information (COP1A)",
+                "name" => "upload-cop1a"
+              }
+            ],
+            "steps" => [
+              "page.upload-cop1a-check"
+            ],
+            "url" => "upload-cop1a"
+          },
+        ],
+        "locale" => "en"
+      }
+      expect(response_body).to include(expected)
+    end
+  end
+
+  context 'when invalid attributes' do
+    let(:params) { { metadata: {'foo': 'bar'}} }
+
+    it 'returns unprocessable entity' do
+      expect(response.status).to be(422)
+    end
+
+    it 'returns error messages' do
+      expect(response_body['message']).to eq(
+        [
+          "Metadata created by can't be blank",
+          "Name can't be blank",
+          "Created by can't be blank"
+        ]
+      )
+    end
+  end
+end

--- a/spec/requests/create_version_spec.rb
+++ b/spec/requests/create_version_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe 'POST /services/:id/versions' do
       }
     end
 
-    it 'returns success status' do
-      expect(response.status).to be(200)
+    it 'returns created status' do
+      expect(response.status).to be(201)
     end
 
     it 'returns the metadata' do

--- a/spec/requests/create_version_spec.rb
+++ b/spec/requests/create_version_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe 'POST /services/:id/versions' do
   let(:service) { create(:service) }
 
   before do
-    post "/services/#{service.id}/versions", params: params
+    post "/services/#{service.id}/versions", params: params, as: :json
   end
 
   context 'when valid attributes' do
@@ -29,7 +29,7 @@ RSpec.describe 'POST /services/:id/versions' do
                 {
                   "_id": "page.upload-cop1a--upload.auto_name__1",
                   "_type": "upload",
-#                  "my_awesome_errors": {},
+                 "errors": {},
                   "hint": "",
                   "label": "Upload your completed supporting information (COP1A)",
                   "name": "upload-cop1a"
@@ -72,7 +72,7 @@ RSpec.describe 'POST /services/:id/versions' do
               {
                 "_id" => "page.upload-cop1a--upload.auto_name__1",
                 "_type" => "upload",
-#                "errors" => {},
+               "errors" => {},
                 "hint" => "",
                 "label" => "Upload your completed supporting information (COP1A)",
                 "name" => "upload-cop1a"


### PR DESCRIPTION
## Make POST /services/:service_id/versions

## Get latest version by created_at

## Create Metadata Serialiser

## Set content type in the request specs to be json

Rails has a strong parameter mechanism that removes empty hashes and
empty arrays if they are passed in the JSON request body.

The way round this is to set the header to be `as: :json` in the spec

## Add create service and create version fixtures

https://trello.com/c/a4RisjKm/982-update-service-endpoint-service-versions

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>