### PR TITLE
Change get latest service version route

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,12 +1,4 @@
 class ServicesController < ApplicationController
-  def show
-    service = Service.find(params[:id])
-    locale = params[:locale] || 'en'
-    metadata = service.metadata.by_locale(locale).latest_version
-
-    render json: MetadataSerialiser.new(service, metadata).attributes, status: :ok
-  end
-
   def create
     service = Service.new(service_params)
 

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -13,4 +13,12 @@ class VersionsController < ApplicationController
       render json: { message: service.errors.full_messages }, status: :unprocessable_entity
     end
   end
+
+  def latest
+    service = Service.find(params[:service_id])
+    locale = params[:locale] || 'en'
+    metadata = service.metadata.by_locale(locale).latest_version
+
+    render json: MetadataSerialiser.new(service, metadata).attributes, status: :ok
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   get '/health', to: 'health#show'
 
-  resources :services, only: [:show, :create] do
-    resources :versions, only: :create
+  resources :services, only: [:create] do
+    resources :versions, only: :create do
+      get :latest, on: :collection
+    end
   end
 end

--- a/spec/requests/get_latest_version_spec.rb
+++ b/spec/requests/get_latest_version_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'GET /services/:id' do
+RSpec.describe 'GET /services/:service_id/versions/latest' do
   let(:response_body) { JSON.parse(response.body) }
 
   context 'when service exists' do
@@ -20,7 +20,7 @@ RSpec.describe 'GET /services/:id' do
       end
 
       before do
-        get "/services/#{service.id}", as: :json
+        get "/services/#{service.id}/versions/latest", as: :json
       end
 
       it 'returns success response' do
@@ -63,7 +63,7 @@ RSpec.describe 'GET /services/:id' do
       end
 
       before do
-        get "/services/#{service.id}?locale=cy", as: :json
+        get "/services/#{service.id}/versions/latest?locale=cy", as: :json
       end
 
       it 'returns success response' do
@@ -86,7 +86,7 @@ RSpec.describe 'GET /services/:id' do
 
   context 'when service does not exist' do
     before do
-      get "/services/1234-abcdef", as: :json
+      get "/services/1234-abcdef/versions/latest", as: :json
     end
 
     it 'returns not found response' do


### PR DESCRIPTION
To better show what it is exactly that is being returned we are changing the route that gets the latest service metadata to:

`GET /services/<service_id>/versions/latest`

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>