### PR TITLE
Add get all service metadata versions endpoint

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,7 +1,5 @@
 class VersionsController < ApplicationController
   def create
-    service = Service.find(params[:service_id])
-
     if service.update(service_params)
       metadata = service.latest_metadata
 
@@ -15,10 +13,22 @@ class VersionsController < ApplicationController
   end
 
   def latest
-    service = Service.find(params[:service_id])
-    locale = params[:locale] || 'en'
     metadata = service.metadata.by_locale(locale).latest_version
 
     render json: MetadataSerialiser.new(service, metadata).attributes, status: :ok
+  end
+
+  def index
+    versions = service.metadata.by_locale(locale).all_versions.ordered
+
+    render json: VersionsSerialiser.new(service, versions).attributes, status: :ok
+  end
+
+  def service
+    @_service ||= Service.find(params[:service_id])
+  end
+
+  def locale
+    @_locale ||= params[:locale] || 'en'
   end
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -3,5 +3,7 @@ class Metadata < ApplicationRecord
   validates :locale, :data, :created_by, presence: true
 
   scope :by_locale, lambda { |locale| where(locale: locale) }
-  scope :latest_version, -> { order(created_at: :desc).first }
+  scope :latest_version, -> { ordered.first }
+  scope :ordered, -> { order(created_at: :desc) }
+  scope :all_versions, -> { select(:id, :created_at) }
 end

--- a/app/serialisers/metadata_serialiser.rb
+++ b/app/serialisers/metadata_serialiser.rb
@@ -1,6 +1,4 @@
 class MetadataSerialiser
-  include ActiveModel::Serializers::JSON
-
   attr_accessor :service, :metadata
 
   def initialize(service, metadata)

--- a/app/serialisers/versions_serialiser.rb
+++ b/app/serialisers/versions_serialiser.rb
@@ -1,0 +1,27 @@
+class VersionsSerialiser
+  attr_accessor :service, :versions
+
+  def initialize(service, versions)
+    @service = service
+    @versions = versions
+  end
+
+  def attributes
+    {
+      service_id: service.id,
+      service_name: service.name,
+      versions: all_versions
+    }
+  end
+
+  private
+
+  def all_versions
+    versions.map do |version|
+      {
+        version_id: version.id,
+        created_at: version.created_at.iso8601
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   get '/health', to: 'health#show'
 
   resources :services, only: [:create] do
-    resources :versions, only: :create do
+    resources :versions, only: [:index, :create] do
       get :latest, on: :collection
     end
   end

--- a/spec/requests/get_all_versions_spec.rb
+++ b/spec/requests/get_all_versions_spec.rb
@@ -1,0 +1,108 @@
+RSpec.describe 'GET /services/:service_id/versions' do
+  let(:response_body) { JSON.parse(response.body) }
+
+  context 'when service exists' do
+    context 'when default locale' do
+      let(:service) do
+        create(:service,
+               metadata: [first_version, latest_version])
+      end
+      let(:first_version) do
+        build(:metadata)
+      end
+      let(:latest_version) do
+        build(:metadata, data: {
+          configuration: {
+            email_input_name_user: 'mojo'
+          },
+          pages: []
+        })
+      end
+
+      before do
+        get "/services/#{service.id}/versions", as: :json
+      end
+
+      it 'returns success response' do
+        expect(response.status).to be(200)
+      end
+
+      it 'returns all versions of the service' do
+        expect(response_body).to eq({
+          'service_id' => service.id,
+          'service_name' => service.name,
+          'versions' => [
+            {
+              'version_id' => latest_version.id,
+              'created_at' => latest_version.created_at.iso8601
+            },
+            {
+              'version_id' => first_version.id,
+              'created_at' => first_version.created_at.iso8601
+            }
+          ],
+        })
+      end
+    end
+
+    context 'when requesting locale' do
+      let(:service) do
+        create(:service,
+               metadata: [welsh_version, english_version])
+      end
+      let(:welsh_version) do
+        build(:metadata, data: {
+          configuration: {
+            pdf_heading: 'Helo Byd!'
+          },
+          pages: []
+        }, locale: 'cy')
+      end
+      let(:english_version) do
+        build(:metadata, data: {
+          configuration: {
+            email_input_name_user: 'mojo'
+          },
+          pages: []
+        })
+      end
+
+      before do
+        get "/services/#{service.id}/versions?locale=cy", as: :json
+      end
+
+      it 'returns success response' do
+        expect(response.status).to be(200)
+      end
+
+      it 'returns all versions of the service' do
+        expect(response_body).to eq({
+          'service_id' => service.id,
+          'service_name' => service.name,
+          'versions' => [
+            {
+              'version_id' => welsh_version.id,
+              'created_at' => welsh_version.created_at.iso8601
+            }
+          ]
+        })
+      end
+    end
+  end
+
+  context 'when service does not exist' do
+    before do
+      get '/services/1234-abcdef/versions', as: :json
+    end
+
+    it 'returns not found response' do
+      expect(response.status).to be(404)
+    end
+
+    it 'returns not found message' do
+      expect(response_body).to eq({
+        'message' => ['Requested Service not found']
+      })
+    end
+  end
+end


### PR DESCRIPTION
This adds the `GET /services/<service_id>/versions` endpoint which will return a response object which contains all the version_id's and the created_at's for the given service_id.

We also removed the ActiveModel::JSON serializer because we were not actually using its' interface.

https://trello.com/c/8zPzleCN/999-get-all-versions-for-a-service-endpoint

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>