### PR TITLE
Add encoded keys to the environment

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/config_map.yaml
+++ b/deploy/fb-metadata-api-chart/templates/config_map.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fb-metadata-api-env-{{ .Values.environmentName }}
+  name: fb-metadata-api-config-map
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 data:
   RAILS_ENV: production
+  ENCODED_PRIVATE_KEY: {{ .Values.encoded_private_key }}
+  ENCODED_PUBLIC_KEY: {{ .Values.encoded_public_key }}

--- a/deploy/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy/fb-metadata-api-chart/templates/deployment.yaml
@@ -48,6 +48,11 @@ spec:
               secretKeyRef:
                 name: fb-metadata-api-secrets-{{ .Values.environmentName }}
                 key: secret_key_base
+          - name: ENCODED_PRIVATE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: fb-metadata-api-secrets-{{ .Values.environmentName }}
+                key: encoded_private_key
           # secrets created by terraform
           # which may or may not depend on values
           # canonically defined in secrets.tfvars

--- a/deploy/fb-metadata-api-chart/templates/secrets.yaml
+++ b/deploy/fb-metadata-api-chart/templates/secrets.yaml
@@ -6,3 +6,4 @@ metadata:
 type: Opaque
 data:
   secret_key_base: {{ .Values.secret_key_base }}
+  encoded_private_key: {{ .Values.encoded_private_key }}


### PR DESCRIPTION
The JWT authentication requires requests that the metadata API makes in the future to encode using private keys. Therefore we set the keys in the K8S config map for each environment.