### PR TITLE
Add the proper config map name to k8s deployment manifest

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy/fb-metadata-api-chart/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
         # defined in config_map.yaml
         envFrom:
           - configMapRef:
-              name: fb-metadata-api-env-{{ .Values.environmentName }}
+              name: fb-metadata-api-config-map
         env:
           - name: SENTRY_CURRENT_ENV
             value: {{ .Values.environmentName }}


### PR DESCRIPTION
The deployment are failing on https://app.circleci.com/pipelines/github/ministryofjustice/fb-metadata-api/61/workflows/c63abb65-9754-480a-9402-e34a1e89bfe5/jobs/94
because the config map name was changed. Changing the old config map
name to the new one fix the issue