### PR TITLE
Add namespace to service token cache url

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/config_map.yaml
+++ b/deploy/fb-metadata-api-chart/templates/config_map.yaml
@@ -12,5 +12,5 @@ data:
   # and the app should request to test-production and live-production
   # respectively.
   #
-  SERVICE_TOKEN_CACHE_ROOT_URL: "http://fb-service-token-cache-svc-{{ .Values.environmentName }}-production/"
+  SERVICE_TOKEN_CACHE_ROOT_URL: "http://fb-service-token-cache-svc-{{ .Values.environmentName }}-production.formbuilder-platform-{{ .Values.environmentName }}-production/"
   MAX_IAT_SKEW_SECONDS: "60"


### PR DESCRIPTION
Following the cloud platform guides here:
https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/network-policy.html#network-policy

"To access a service in the target namespace, we won’t be able to simply use the service name anymore.
We have to use <serviceName>.<namespaceName>."

So adding the namespace and tested on test-production and it worked!

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>