### PR TITLE
Add error message when route doesn't exist

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,14 @@
 class ApplicationController < ActionController::API
-  RECORD_NOT_FOUND_EXCEPTIONS = [
+  NOT_FOUND_EXCEPTIONS = [
     ActiveRecord::RecordNotFound,
     MetadataVersionNotFound
   ]
-  rescue_from(*RECORD_NOT_FOUND_EXCEPTIONS) do |exception|
+  rescue_from(*NOT_FOUND_EXCEPTIONS) do |exception|
     render json: ErrorsSerializer.new(
-      exception, message: exception.message
+      message: exception.message
     ).attributes, status: :not_found
   end
+
   FB_JWT_EXCEPTIONS = [
     Fb::Jwt::Auth::TokenNotPresentError,
     Fb::Jwt::Auth::TokenNotValidError,
@@ -17,17 +18,19 @@ class ApplicationController < ActionController::API
   ]
   rescue_from(*FB_JWT_EXCEPTIONS) do |exception|
     render json: ErrorsSerializer.new(
-      exception, message: exception.message
+      message: exception.message
     ).attributes, status: :unauthorized
   end
 
   before_action AuthenticateApplication
 
-  private
-
-  def resource_not_found(exception)
-    render json: ErrorsSerializer.new(exception).attributes, status: :not_found
+  def not_found
+    render json: ErrorsSerializer.new(
+      message: "No route matches #{request.method} '#{request.path}'"
+    ).attributes, status: :not_found
   end
+
+  private
 
   def service_params
     params.permit(:metadata)

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -12,7 +12,6 @@ class ServicesController < ApplicationController
     else
       render json:
         ErrorsSerializer.new(
-          service,
           message: service.errors.full_messages
       ).attributes, status: :unprocessable_entity
     end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -9,7 +9,6 @@ class VersionsController < ApplicationController
       )
     else
       render json: ErrorsSerializer.new(
-        service,
         message: service.errors.full_messages
       ).attributes, status: :unprocessable_entity
     end

--- a/app/serialisers/errors_serializer.rb
+++ b/app/serialisers/errors_serializer.rb
@@ -1,8 +1,7 @@
 class ErrorsSerializer
   attr_reader :object, :message
 
-  def initialize(object, message:)
-    @object = object
+  def initialize(message:)
     @message = message
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
       get :latest, on: :collection
     end
   end
+
+  match '*unmatched', to: 'application#not_found', via: :all
 end

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -350,4 +350,23 @@ RSpec.describe 'API integration tests' do
       ).to match_array(['Token is not valid: error Signature verification raised'])
     end
   end
+
+  context 'when route does not exist' do
+    let(:response) do
+      MetadataApiTestClient.get(
+        '/services/i-dont-exist-9999',
+        headers: authorisation_headers
+      )
+    end
+
+    it 'returns not found' do
+      expect(response.code).to be(404)
+    end
+
+    it 'returns a error message' do
+      expect(
+        JSON.parse(response.body, symbolize_names: true)[:message]
+      ).to eq(["No route matches GET '/services/i-dont-exist-9999'"])
+    end
+  end
 end


### PR DESCRIPTION
When we request a route that doesn't exist we should
return a 404 JSON response containing the message
that the requested url doesn't exist.