### PR TITLE
Validation schemas

### DIFF
--- a/schemas/condition/condition.json
+++ b/schemas/condition/condition.json
@@ -1,0 +1,48 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/condition",
+  "_name": "condition",
+  "title": "Condition",
+  "type": "object",
+  "allOf": [
+    {
+      "properties": {
+        "_id": {
+          "title": "Condition ID",
+          "type": "string"
+        },
+        "_type": {
+          "title": "Type",
+          "type": "string",
+          "const": "condition"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "negated": {
+          "title": "Negated",
+          "type": "boolean"
+        }
+      }
+    },
+    {
+      "oneOf": [
+        {
+          "$ref": "definition.condition.expression"
+        },
+        {
+          "$ref": "definition.conditions.all"
+        },
+        {
+          "$ref": "definition.conditions.any"
+        },
+        {
+          "$ref": "definition.conditions.exactly"
+        }
+      ]
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.base.json
+++ b/schemas/definition/condition.base.json
@@ -7,7 +7,7 @@
       "title": "Identifier",
       "type": "string"
     },
-    "identifierType": {
+    "identifier_type": {
       "title": "Identifier type",
       "type": "string",
       "enum": [

--- a/schemas/definition/condition.boolean.json
+++ b/schemas/definition/condition.boolean.json
@@ -1,0 +1,25 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/boolean",
+  "_name": "definition.condition.boolean",
+  "title": "Boolean condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "isTrue"
+      ]
+    }
+  },
+  "required": [
+    "operator"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.defined.json
+++ b/schemas/definition/condition.defined.json
@@ -1,0 +1,25 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/defined",
+  "_name": "definition.condition.defined",
+  "title": "Defined condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "defined"
+      ]
+    }
+  },
+  "required": [
+    "operator"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.expression.json
+++ b/schemas/definition/condition.expression.json
@@ -1,0 +1,22 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/expression",
+  "_name": "definition.condition.expression",
+  "title": "Single expression condition properties",
+  "oneOf": [
+    {
+      "$ref": "definition.condition.defined"
+    },
+    {
+      "$ref": "definition.condition.text"
+    },
+    {
+      "$ref": "definition.condition.number"
+    },
+    {
+      "$ref": "definition.condition.boolean"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.number.json
+++ b/schemas/definition/condition.number.json
@@ -1,0 +1,49 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/number",
+  "_name": "definition.condition.number",
+  "title": "Number condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "equals",
+        "greater_than",
+        "greater_than_or_equal_to",
+        "less_than",
+        "less_than_or_equal_to",
+        "multiple_of"
+      ]
+    },
+    "value": {
+      "title": "Value"
+    }
+  },
+  "if": {
+    "required": [
+      "value_type"
+    ]
+  },
+  "then": {
+    "$ref": "definition.condition.value_type"
+  },
+  "else": {
+    "properties": {
+      "value": {
+        "type": "number"
+      }
+    }
+  },
+  "required": [
+    "operator",
+    "value"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.text.json
+++ b/schemas/definition/condition.text.json
@@ -1,0 +1,48 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/text",
+  "_name": "definition.condition.text",
+  "title": "Text condition properties",
+  "allOf": [
+    {
+      "$ref": "definition.condition.base"
+    }
+  ],
+  "properties": {
+    "operator": {
+      "title": "Operator",
+      "type": "string",
+      "enum": [
+        "is",
+        "starts_with",
+        "ends_with",
+        "includes",
+        "match"
+      ]
+    },
+    "value": {
+      "title": "Value"
+    }
+  },
+  "if": {
+    "required": [
+      "value_type"
+    ]
+  },
+  "then": {
+    "$ref": "definition.condition.value_type"
+  },
+  "else": {
+    "properties": {
+      "value": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "operator",
+    "value"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/condition.value_type.json
+++ b/schemas/definition/condition.value_type.json
@@ -1,0 +1,24 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/condition/value_type",
+  "_name": "definition.condition.value_type",
+  "title": "Condition value type properties",
+  "properties": {
+    "value": {
+      "type": "string"
+    },
+    "value_type": {
+      "type": "string",
+      "enum": [
+        "value",
+        "input",
+        "feature"
+      ]
+    }
+  },
+  "required": [
+    "value_type"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/conditional.boolean.json
+++ b/schemas/definition/conditional.boolean.json
@@ -11,7 +11,7 @@
       "type": "boolean"
     },
     {
-      "$ref": "condition.base"
+      "$ref": "condition"
     }
   ],
   "category": [

--- a/schemas/definition/conditions.all.json
+++ b/schemas/definition/conditions.all.json
@@ -1,0 +1,20 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditions/all",
+  "_name": "definition.conditions.all",
+  "title": "All conditions met properties",
+  "properties": {
+    "all": {
+      "title": "All conditions met",
+      "type": "array",
+      "items": {
+        "$ref": "condition"
+      }
+    }
+  },
+  "required": [
+    "all"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/conditions.any.json
+++ b/schemas/definition/conditions.any.json
@@ -1,0 +1,26 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditions/any",
+  "_name": "definition.conditions.any",
+  "title": "At least conditions met properties",
+  "properties": {
+    "any": {
+      "title": "At least X conditions met",
+      "type": "array",
+      "items": {
+        "$ref": "condition"
+      }
+    },
+    "conditions_met": {
+      "title": "Number of conditions to meet",
+      "type": "number",
+      "minimum": 1,
+      "default": 1
+    }
+  },
+  "required": [
+    "any"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/definition/conditions.exactly.json
+++ b/schemas/definition/conditions.exactly.json
@@ -1,0 +1,26 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/conditions/exactly",
+  "_name": "definition.conditions.exactly",
+  "title": "Exactly conditions met properties",
+  "properties": {
+    "exactly": {
+      "title": "Exactly X conditions met",
+      "type": "array",
+      "items": {
+        "$ref": "condition"
+      }
+    },
+    "conditions_met": {
+      "title": "Number of conditions to meet",
+      "type": "number",
+      "minimum": 1,
+      "default": 1
+    }
+  },
+  "required": [
+    "exactly"
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/text/text.json
+++ b/schemas/text/text.json
@@ -11,13 +11,13 @@
   },
   "allOf": [
     {
-      "$ref": "../definition/field.json"
+      "$ref": "definition.field"
     },
     {
-      "$ref": "../validations#/definitions/string_bundle"
+      "$ref": "validations#/definitions/string_bundle"
     },
     {
-      "$ref": "../definition/width_class.input.json"
+      "$ref": "definition.width_class.input"
     }
   ]
 }

--- a/schemas/validations/validations.json
+++ b/schemas/validations/validations.json
@@ -32,7 +32,7 @@
       "description": "Whether the user must answer a question",
       "oneOf": [
         {
-          "$ref": "../definition/conditional.boolean.json"
+          "$ref": "definition.conditional.boolean"
         }
       ],
       "default": true

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'API integration tests' do
           authorisation_headers: authorisation_headers
         ))[:services]
 
-        expect(services_for_user).to eq(services.flatten)
+        expect(services_for_user).to match_array(services.flatten)
       end
     end
 


### PR DESCRIPTION
## Add schemas necessary for text field validation

This adds all the referenced schemas required for text field validation. There are so many because the validation for required is a boolean condition which references a lot!

https://trello.com/c/Crwo6jqv/1124-validation-for-the-text-field-component