### PR TITLE
Migrate more top level schemas required for errors

### DIFF
--- a/config/initializers/schemas.rb
+++ b/config/initializers/schemas.rb
@@ -1,8 +1,13 @@
 Rails.application.config.schemas_directory = File.join(Rails.root, 'schemas')
 
+Rails.logger.info('Loading all schemas')
 schemas = Dir.glob("#{Rails.application.config.schemas_directory}/*/**")
 schemas.each do |schema_file|
   schema = JSON.parse(File.read(schema_file))
+
+  Rails.logger.info(schema['_name'])
   jschema = JSON::Schema.new(schema, Addressable::URI.parse(schema['_name']))
   JSON::Validator.add_schema(jschema)
 end
+
+Rails.logger.info("Total loaded schemas => #{JSON::Validator.schemas.count}")

--- a/schemas/config/meta.json
+++ b/schemas/config/meta.json
@@ -1,0 +1,27 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/config/meta",
+  "_name": "config.meta",
+  "title": "Form meta links",
+  "description": "List of links to display in GOVUK footer",
+  "usage": "Use the config.meta component to provide a list of links in the footer",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "definition.link_list"
+    }
+  ],
+  "properties": {
+    "_id": {
+      "const": "config.meta"
+    },
+    "_type": {
+      "const": "config.meta"
+    },
+    "title": {
+      "type": "null"
+    }
+  },
+  "category": [
+    "configuration"
+  ]
+}

--- a/schemas/config/service.json
+++ b/schemas/config/service.json
@@ -6,10 +6,25 @@
   "type": "object",
   "properties": {
     "_id": {
-      "const": "service"
+      "const": "config.service"
     },
     "_type": {
       "const": "config.service"
+    },
+    "homepage_url": {
+      "title": "Homepage URL",
+      "description": "The Homepage URL of the service",
+      "type": "string"
+    },
+    "service_email_address": {
+      "title": "Service Email Address",
+      "description": "The email address of the service",
+      "type": "string"
+    },
+    "service_url": {
+      "title": "Service URL",
+      "description": "The URL of the first page of the service",
+      "type": "string"
     },
     "phase": {
       "title": "Form phase",

--- a/schemas/definition/link_list.json
+++ b/schemas/definition/link_list.json
@@ -1,0 +1,30 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/link_list",
+  "_name": "definition.link_list",
+  "title": "Link list definition",
+  "type": "object",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "description": "Title/heading to display",
+      "type": "string",
+      "content": true
+    },
+    "items": {
+      "title": "Items",
+      "description": "Items that make up list",
+      "type": "array",
+      "items": {
+        "$ref": "link"
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/errors/errors.json
+++ b/schemas/errors/errors.json
@@ -1,0 +1,142 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/errors",
+  "_name": "errors",
+  "title": "Error strings",
+  "type": "object",
+  "definitions": {
+    "error_strings": {
+      "type": "object",
+      "properties": {
+        "inline": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        }
+      }
+    },
+    "required": {
+      "title": "Error strings for required",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "min_length": {
+      "title": "Error strings for minimum length",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "max_length": {
+      "title": "Error strings for maximum length",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "pattern": {
+      "title": "Error strings for pattern",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "multiple_of": {
+      "title": "Error strings for multiple of",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "maximum": {
+      "title": "Error strings for maximum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "exclusive_maximum": {
+      "title": "Error strings for exclusive maximum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "minimum": {
+      "title": "Error strings for minimum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "exclusive_minimum": {
+      "title": "Error strings for exclusive minimum",
+      "allOf": [
+        {
+          "$ref": "#/definitions/error_strings"
+        }
+      ]
+    },
+    "required_errors": {
+      "properties": {
+        "errors": {
+          "properties": {
+            "required": {
+              "$ref": "#/definitions/required"
+            }
+          }
+        }
+      }
+    },
+    "string_errors": {
+      "properties": {
+        "errors": {
+          "properties": {
+            "min_length": {
+              "$ref": "#/definitions/min_length"
+            },
+            "max_length": {
+              "$ref": "#/definitions/max_length"
+            },
+            "pattern": {
+              "$ref": "#/definitions/pattern"
+            }
+          }
+        }
+      }
+    },
+    "number_errors": {
+      "properties": {
+        "errors": {
+          "properties": {
+            "multiple_of": {
+              "$ref": "#/definitions/multiple_of"
+            },
+            "maximum": {
+              "$ref": "#/definitions/maximum"
+            },
+            "exclusive_maximum": {
+              "$ref": "#/definitions/exclusive_maximum"
+            },
+            "minimum": {
+              "$ref": "#/definitions/minimum"
+            },
+            "exclusive_minimum": {
+              "$ref": "#/definitions/exclusive_minimum"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/link/link.json
+++ b/schemas/link/link.json
@@ -1,0 +1,46 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/link",
+  "_name": "link",
+  "title": "Link",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "link"
+    },
+    "text": {
+      "title": "Link text",
+      "description": "Link text to display",
+      "type": "string",
+      "content": true
+    },
+    "href": {
+      "title": "Link url",
+      "description": "Page Id or absolute url",
+      "type": "string",
+      "content": true,
+      "url": true
+    },
+    "active": {
+      "title": "Active",
+      "description": "Whether link is active",
+      "type": "boolean"
+    },
+    "attributes": {
+      "title": "Link attributes",
+      "description": "Attributes to pass to link",
+      "type": "object"
+    }
+  },
+  "required": [
+    "text",
+    "href"
+  ],
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    }
+  ],
+  "category": [
+    "definition"
+  ]
+}

--- a/schemas/request/services.json
+++ b/schemas/request/services.json
@@ -8,6 +8,12 @@
     "metadata": {
       "type": "object",
       "properties": {
+        "_id": {
+          "const": "service.base"
+        },
+        "_type": {
+          "const": "service.base"
+        },
         "service_name": {
           "type": "string"
         },
@@ -28,6 +34,8 @@
         }
       },
       "required": [
+        "_id",
+        "_type",
         "service_name",
         "created_by",
         "configuration",

--- a/schemas/service/base.json
+++ b/schemas/service/base.json
@@ -5,6 +5,12 @@
   "description": "Base schema for a service",
   "type": "object",
   "properties": {
+    "_id": {
+      "const": "service.base"
+    },
+    "_type": {
+      "const": "service.base"
+    },
     "service_id": {
       "type": "string"
     },
@@ -34,6 +40,8 @@
     }
   },
   "required": [
+    "_id",
+    "_type",
     "service_id",
     "service_name",
     "created_by",

--- a/spec/fixtures/create_service.json
+++ b/spec/fixtures/create_service.json
@@ -1,5 +1,7 @@
 {
   "metadata": {
+    "_id": "service.base",
+    "_type": "service.base",
     "service_name": "Service Name",
     "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
     "configuration": {

--- a/spec/fixtures/create_version.json
+++ b/spec/fixtures/create_version.json
@@ -1,5 +1,7 @@
 {
   "metadata": {
+    "_id": "service.base",
+    "_type": "service.base",
     "service_name": "Service Name",
     "service_id": "9dd24696-96dd-43e4-83a8-96b7497827ed",
     "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",

--- a/spec/fixtures/service.json
+++ b/spec/fixtures/service.json
@@ -1,4 +1,6 @@
 {
+  "_id": "service.base",
+  "_type": "service.base",
   "service_name": "Complain about a court or tribunal",
   "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
   "configuration": {

--- a/spec/fixtures/version.json
+++ b/spec/fixtures/version.json
@@ -1,4 +1,6 @@
 {
+  "_id": "service.base",
+  "_type": "service.base",
   "service_id": "d243f5c0-e8a2-4b13-982c-7b5f3fa128cf",
   "service_name": "Complain about a court or tribunal",
   "created_at": "2020-10-09T11:51:46",

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe 'API integration tests' do
         expect(
           parse_response(response)[:message]
         ).to match_array(
-          ["The property '#/metadata' did not contain a required property of 'service_name'"]
+          ["The property '#/metadata' did not contain a required property of '_id'"]
         )
       end
 
@@ -237,7 +237,7 @@ RSpec.describe 'API integration tests' do
         expect(
           parse_response(response)[:message]
         ).to match_array(
-          ["The property '#/metadata' did not contain a required property of 'service_id'"]
+          ["The property '#/metadata' did not contain a required property of '_id'"]
         )
       end
     end

--- a/spec/requests/create_service_spec.rb
+++ b/spec/requests/create_service_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe 'POST /services', type: :request do
     let(:params) do
       {
         "metadata": {
+          "_id": "service.base",
+          "_type": "service.base",
           "service_name": "Service Name",
           "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
           "configuration": {
@@ -39,6 +41,8 @@ RSpec.describe 'POST /services', type: :request do
 
     it 'returns service representation' do
       expected = {
+        "_id" => "service.base",
+        "_type" => "service.base",
         "service_name" => "Service Name",
         "created_by" => "4634ec01-5618-45ec-a4e2-bb5aa587e751",
         "configuration" => {
@@ -74,6 +78,8 @@ RSpec.describe 'POST /services', type: :request do
     let(:params) do
       {
         metadata: {
+          "_id": 'service.base',
+          "_type": 'service.base',
           service_name: 'Service Name',
           created_by: '4634ec01-5618-45ec-a4e2-bb5aa587e751',
           configuration: {
@@ -94,11 +100,13 @@ RSpec.describe 'POST /services', type: :request do
     let(:params) do
       {
         metadata: {
+          "_id": 'service.base',
+          "_type": 'service.base',
           service_name: 'Helo Byd',
           created_by: '4634ec01-5618-45ec-a4e2-bb5aa587e751',
           configuration: {
-            "_id": "service",
-            "_type": "config.service"
+            "_id": 'config.service',
+            "_type": 'config.service'
           },
           pages: [],
           locale: 'cy'

--- a/spec/requests/create_version_spec.rb
+++ b/spec/requests/create_version_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'POST /services/:id/versions' do
     let(:params) do
       {
         "metadata": {
+          "_id": "service.base",
+          "_type": "service.base",
           "service_name": "Service Name",
           "service_id": service.id,
           "created_by": "4634ec01-5618-45ec-a4e2-bb5aa587e751",
@@ -103,7 +105,7 @@ RSpec.describe 'POST /services/:id/versions' do
       expect(
         response_body['message']
       ).to eq(
-        ["The property '#/metadata' did not contain a required property of 'service_id'"]
+        ["The property '#/metadata' did not contain a required property of '_id'"]
       )
     end
   end


### PR DESCRIPTION
These adds a lot more additional schemas that are required for rendering an error.

Also some of the schemas for the top level service and footer "meta".

We also add _id and _type to the base schema as those properties were missing.