### PR TITLE
Add schemas for the start page and the single question page

### DIFF
--- a/schemas/definition/components.json
+++ b/schemas/definition/components.json
@@ -1,0 +1,15 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/components",
+  "_name": "definition.components",
+  "title": "Components definition",
+  "properties": {
+    "components": {
+      "title": "Components",
+      "description": "The form or content elements used on the page",
+      "type": "array",
+      "items": {
+        "$ref": "definition.component"
+      }
+    }
+  }
+}

--- a/schemas/definition/next_page.json
+++ b/schemas/definition/next_page.json
@@ -1,0 +1,40 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/nextpage",
+  "_name": "definition.nextpage",
+  "title": "Next page",
+  "description": "What page (or pages) to go to next, and under what conditions. Only use if what you’re trying to achieve is impossible or extremely difficult using page steps",
+  "oneOf": [
+    {
+      "type": "string"
+    },
+    {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "page": {
+                "type": "string"
+              },
+              "condition": {
+                "$ref": "definition.conditional.boolean"
+              }
+            },
+            "required": [
+              "page",
+              "condition"
+            ]
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
+    }
+  ],
+  "category": [
+    "logic",
+    "definition"
+  ]
+}

--- a/schemas/definition/page.form.json
+++ b/schemas/definition/page.form.json
@@ -1,0 +1,96 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/page/form",
+  "_name": "definition.page.form",
+  "title": "Form page definition",
+  "properties": {
+    "extra_components": {
+      "title": "Additional components",
+      "description": "Components following continue button",
+      "type": "array",
+      "items": {
+        "$ref": "definition.component"
+      },
+      "accepts": [
+        "content"
+      ],
+      "category": [
+        "additional"
+      ]
+    },
+    "section_heading": {
+      "title": "Section heading",
+      "description": "Name of section",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "section_heading_summary": {
+      "title": "Section heading (Summary version)",
+      "description": "A condensed version of the section heading, for use on the 'check your answers' page",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "heading_summary": {
+      "title": "Heading (Summary version)",
+      "description": "A condensed version of the page heading, for use on the 'check your answers' page",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "steps_heading": {
+      "title": "Steps heading",
+      "description": "Name of section to use on step pages (if any)",
+      "type": "string",
+      "category": [
+        "content"
+      ]
+    },
+    "steps": {
+      "title": "Steps",
+      "description": "The ‘child’ pages that follow from this ‘parent’ page",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "enable_steps": {
+      "title": "Enable steps",
+      "description": "Allow current page to have steps",
+      "type": "boolean"
+    },
+    "show_steps": {
+      "title": "Steps visibility",
+      "category": [
+        "logic"
+      ],
+      "description": "Whether to show or hide the page’s steps",
+      "oneOf": [
+        {
+          "$ref": "definition.conditional.boolean"
+        }
+      ],
+      "default": true
+    },
+    "nextPage": {
+      "$ref": "definition.next_page"
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page"
+    },
+    {
+      "$ref": "definition.repeatable"
+    }
+  ],
+  "category": [
+    "form_page"
+  ]
+}

--- a/schemas/definition/page.json
+++ b/schemas/definition/page.json
@@ -1,0 +1,109 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/definition/page",
+  "_name": "definition.page",
+  "id_seed": "url",
+  "title": "Page definition",
+  "properties": {
+    "url": {
+      "title": "URL",
+      "description": "The page’s relative url - it must not contain any spaces",
+      "type": "string",
+      "pattern": "^[\\w\\-_\\/]+$"
+    },
+    "heading": {
+      "title": "Heading",
+      "description": "The page’s top-level heading (H1) - appears at the top of the page",
+      "type": "string",
+      "content": true
+    },
+    "title": {
+      "title": "Title",
+      "description": "The text to use as the page’s title in the document title element - uses heading value by default",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "lede": {
+      "title": "First paragraph",
+      "description": "Introductory paragraph after the heading (it‘s also known as the ‘lede’) - use [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format text or add hyperlinks",
+      "type": "string",
+      "content": true,
+      "category": [
+        "content"
+      ]
+    },
+    "body": {
+      "title": "Content",
+      "description": "Free-form content after the heading and first paragraph - use [markdown](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown) to format text or add hyperlinks",
+      "type": "string",
+      "content": true,
+      "multiline": true,
+      "category": [
+        "content"
+      ]
+    },
+    "cookie_message": {
+      "title": "Cookie message",
+      "description": "Set dynamically - exists here to enable formatting of value",
+      "type": "string",
+      "content": true,
+      "default": "[% cookie.message %]",
+      "category": [
+        "dynamic"
+      ]
+    },
+    "action_type": {
+      "title": "Primary action",
+      "description": "Text for primary action button",
+      "type": "string",
+      "enum": [
+        "continue",
+        "save_continue",
+        "save",
+        "confirm",
+        "send.email",
+        "send.sms",
+        "custom-1",
+        "custom-2",
+        "custom-3",
+        "custom-4",
+        "custom-5"
+      ],
+      "default": "continue",
+      "category": [
+        "additional"
+      ]
+    },
+    "back_link": {
+      "title": "Back link text",
+      "type": "string",
+      "default": "[% link.back %]",
+      "content": true,
+      "category": [
+        "additional"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.block"
+    },
+    {
+      "$ref": "definition.components"
+    }
+  ],
+  "required": [
+    "url"
+  ],
+  "category": [
+    "definition",
+    "page"
+  ],
+  "transforms": {
+    "namespace": {
+      "propagation": "components[?(@.$control || @.$grouping)]"
+    }
+  }
+}

--- a/schemas/definition/page.singlequestion.json
+++ b/schemas/definition/page.singlequestion.json
@@ -1,0 +1,31 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/singlequestion",
+  "_name": "page.singlequestion",
+  "title": "Single question",
+  "description": "Ask users one question on a page (you can make the question repeatable for additional answers)",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.singlequestion"
+    },
+    "components": {
+      "maxItems": 1,
+      "accepts": [
+        "control"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page.form"
+    }
+  ],
+  "required": [
+    "components"
+  ],
+  "surplus_properties": [
+    "heading",
+    "lede",
+    "body"
+  ]
+}

--- a/schemas/page/start.json
+++ b/schemas/page/start.json
@@ -1,0 +1,34 @@
+{
+  "$id": "http://gov.uk/schema/v1.0.0/page/start",
+  "_name": "page.start",
+  "title": "Start page",
+  "description": "Let users start using a service",
+  "type": "object",
+  "properties": {
+    "_type": {
+      "const": "page.start"
+    },
+    "enable_steps": {
+      "const": true
+    },
+    "components": {
+      "accepts": [
+        "content"
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "definition.page.form"
+    }
+  ],
+  "ui_category": {
+    "main": [
+      "lede",
+      "body"
+    ]
+  },
+  "required": [
+    "steps"
+  ]
+}

--- a/schemas/request/services.json
+++ b/schemas/request/services.json
@@ -29,7 +29,7 @@
         "pages": {
           "type": "array",
           "items": {
-            "type": "object"
+            "$ref": "definition.page"
           }
         }
       },

--- a/schemas/service/base.json
+++ b/schemas/service/base.json
@@ -35,7 +35,7 @@
     "pages": {
       "type": "array",
       "items": {
-        "type": "object"
+        "$ref": "definition.page"
       }
     }
   },


### PR DESCRIPTION
This adds the schemas for the start page as well as the single question page.

Schema validation should now occur for page types as well.