### PR TITLE
Return 403 instead of 401

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::API
   rescue_from(*FB_JWT_EXCEPTIONS) do |exception|
     render json: ErrorsSerializer.new(
       message: exception.message
-    ).attributes, status: :unauthorized
+    ).attributes, status: :forbidden
   end
 
   before_action AuthenticateApplication

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -244,10 +244,10 @@ RSpec.describe 'API integration tests' do
   end
 
   context 'when not passing authorisation token' do
-    it 'returns an unauthorised response with token not present message ' do
+    it 'returns a forbidden response with token not present message ' do
       response = metadata_api_test_client.create_service(body: {}, authorisation_headers: {})
 
-      expect(response.code).to be(401)
+      expect(response.code).to be(403)
       expect(parse_response(response)[:message]).to match_array(['Token is not present'])
     end
   end
@@ -257,13 +257,13 @@ RSpec.describe 'API integration tests' do
       { namespace: 'awesome-namespace', iat: Time.now.to_i }
     end
 
-    it 'returns 401 with issuer not present message' do
+    it 'returns 403 with issuer not present message' do
       response = metadata_api_test_client.create_service(
         body: request_body,
         authorisation_headers: authorisation_headers
       )
 
-      expect(response.code).to be(401)
+      expect(response.code).to be(403)
       expect(
         parse_response(response)[:message]
       ).to match_array(['Issuer is not present in the token'])
@@ -275,13 +275,13 @@ RSpec.describe 'API integration tests' do
       { iss: 'integration-tests', iat: Time.now.to_i }
     end
 
-    it 'returns 401 with namespace not present message' do
+    it 'returns 403 with namespace not present message' do
       response = metadata_api_test_client.create_service(
         body: request_body,
         authorisation_headers: authorisation_headers
       )
 
-      expect(response.code).to be(401)
+      expect(response.code).to be(403)
       expect(
         parse_response(response)[:message]
       ).to match_array(['Namespace is not present in the token'])
@@ -297,13 +297,13 @@ RSpec.describe 'API integration tests' do
       }
     end
 
-    it 'returns 401 with a token has expired message' do
+    it 'returns 403 with a token has expired message' do
       response = metadata_api_test_client.create_service(
         body: request_body,
         authorisation_headers: authorisation_headers
       )
 
-      expect(response.code).to be(401)
+      expect(response.code).to be(403)
       expect(
         parse_response(response)[:message]
       ).to match_array(['Token has expired: iat skew is -86400, max is 60'])

--- a/spec/support/authenticate_application.rb
+++ b/spec/support/authenticate_application.rb
@@ -28,8 +28,8 @@ RSpec.shared_examples 'application authentication' do
       action
     end
 
-    it 'returns unauthorised' do
-      expect(response.status).to be(401)
+    it 'returns forbidden' do
+      expect(response.status).to be(403)
     end
 
     it 'returns response body' do
@@ -45,8 +45,8 @@ RSpec.shared_examples 'application authentication' do
       action
     end
 
-    it 'returns unauthorised' do
-      expect(response.status).to be(401)
+    it 'returns forbidden' do
+      expect(response.status).to be(403)
     end
 
     it 'returns response body' do
@@ -62,8 +62,8 @@ RSpec.shared_examples 'application authentication' do
       action
     end
 
-    it 'returns unauthorised' do
-      expect(response.status).to be(401)
+    it 'returns forbidden' do
+      expect(response.status).to be(403)
     end
 
     it 'returns response body' do
@@ -79,8 +79,8 @@ RSpec.shared_examples 'application authentication' do
       action
     end
 
-    it 'returns unauthorised' do
-      expect(response.status).to be(401)
+    it 'returns forbidden' do
+      expect(response.status).to be(403)
     end
 
     it 'returns response body' do
@@ -96,8 +96,8 @@ RSpec.shared_examples 'application authentication' do
       action
     end
 
-    it 'returns unauthorised' do
-      expect(response.status).to be(401)
+    it 'returns forbidden' do
+      expect(response.status).to be(403)
     end
 
     it 'returns response body' do


### PR DESCRIPTION
A 401 error is returned by a server when a request lacks the correct authentication credentials. However the 401 usually indicates that a client can try to validate again.

An example of this is when basic authentication is used to prompt for a username and a password. The initial request to the server will response with a 401 which the client will then provide a user with an opportunity to enter credentials.

This app being an API there is no such mechanism in place. There is no user to intervene should a request fail to have the valid authentication credentials. Therefore we should just return a 403 (forbidden).

[More info about 401s here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401)