### PR TITLE
Reject metadata that does not have a locale

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.7.2'
 
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'fb-jwt-auth', '~> 0.4.0'
-gem 'metadata_presenter', '~> 0.1.4'
+gem 'metadata_presenter', '~> 0.1.5'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 5.1'
 gem 'rails', '~> 6.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
-    metadata_presenter (0.1.4)
+    metadata_presenter (0.1.5)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -221,7 +221,7 @@ DEPENDENCIES
   factory_bot_rails
   fb-jwt-auth (~> 0.4.0)
   httparty
-  metadata_presenter (~> 0.1.4)
+  metadata_presenter (~> 0.1.5)
   pg (>= 0.18, < 2.0)
   puma (~> 5.1)
   rails (~> 6.1.1)

--- a/spec/requests/create_service_spec.rb
+++ b/spec/requests/create_service_spec.rb
@@ -40,14 +40,6 @@ RSpec.describe 'POST /services', type: :request do
     end
   end
 
-  context 'when no locale is in the metadata' do
-    let(:params) { { metadata: service.reject { |k, _| k == :locale } } }
-
-    it 'should set en as the default' do
-      expect(response_body['locale']).to eq('en')
-    end
-  end
-
   context 'when a locale is in the metadata' do
     let(:params) { { metadata: service.merge(locale: 'cy') } }
 
@@ -55,7 +47,6 @@ RSpec.describe 'POST /services', type: :request do
       expect(response_body['locale']).to eq('cy')
     end
   end
-
 
   context 'when invalid attributes' do
     let(:params) { {} }
@@ -69,6 +60,22 @@ RSpec.describe 'POST /services', type: :request do
         response_body['message']
       ).to match_array(
         ["The property '#/' did not contain a required property of 'metadata'"]
+      )
+    end
+  end
+
+  context 'when no locale is in the metadata' do
+    let(:params) { { metadata: service.reject { |k, _| k == :locale } } }
+
+    it 'returns unprocessable entity' do
+      expect(response.status).to be(422)
+    end
+
+    it 'returns an error message' do
+      expect(
+        response_body['message']
+      ).to match_array(
+        ["The property '#/metadata' did not contain a required property of 'locale'"]
       )
     end
   end


### PR DESCRIPTION
The locale property is required and therefore will be rejected by schema validation in the before filter if it is not present.

This is a result of [this PR](https://github.com/ministryofjustice/fb-metadata-presenter/pull/40) which provides a bit more context as to what triggered this change.