### PR TITLE
Add validation of uniqueness for service name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development, :test do
   gem 'httparty'
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  gem 'database_cleaner-active_record'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,10 @@ GEM
     byebug (11.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    database_cleaner (1.8.5)
+    database_cleaner-active_record (1.8.0)
+      activerecord
+      database_cleaner (~> 1.8.0)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     factory_bot (6.1.0)
@@ -218,6 +222,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   brakeman
   byebug
+  database_cleaner-active_record
   factory_bot_rails
   fb-jwt-auth (~> 0.4.0)
   httparty

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,6 +1,7 @@
 class Service < ApplicationRecord
   has_many :metadata, dependent: :destroy
   validates :name, :created_by, presence: true
+  validates :name, uniqueness: true
   accepts_nested_attributes_for :metadata
 
   def latest_metadata

--- a/db/migrate/20210112113821_change_service_name_to_services.rb
+++ b/db/migrate/20210112113821_change_service_name_to_services.rb
@@ -1,0 +1,5 @@
+class ChangeServiceNameToServices < ActiveRecord::Migration[6.1]
+  def change
+    add_index :services, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_16_094950) do
+ActiveRecord::Schema.define(version: 2021_01_12_113821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2020_10_16_094950) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["created_by"], name: "index_services_on_created_by"
+    t.index ["name"], name: "index_services_on_name", unique: true
   end
 
   add_foreign_key "metadata", "services"

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -134,9 +134,14 @@ RSpec.describe 'API integration tests' do
       let(:user_id) { SecureRandom.uuid }
 
       it 'should return all the services that user contributed to' do
-        services = 2.times.map do
+        services = 2.times.map do |number|
           new_service = parse_response(metadata_api_test_client.create_service(
-            body: { "metadata": service.merge("created_by": user_id) }.to_json,
+            body: {
+              'metadata': service.merge(
+                'created_by': user_id,
+                'service_name': "Service #{number}"
+              )
+            }.to_json,
             authorisation_headers: authorisation_headers
           ))
 
@@ -146,7 +151,12 @@ RSpec.describe 'API integration tests' do
           }
         end
         metadata_api_test_client.create_service(
-          body: { "metadata": service.merge("created_by": SecureRandom.uuid) }.to_json,
+          body: {
+            "metadata": service.merge(
+              "created_by": SecureRandom.uuid,
+              "service_name": 'Moff Gideon'
+            )
+          }.to_json,
           authorisation_headers: authorisation_headers
         )
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
+require 'database_cleaner/active_record'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -37,11 +38,6 @@ RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
-  config.use_transactional_fixtures = true
-
   # You can uncomment this line to turn off ActiveRecord support entirely.
   # config.use_active_record = false
 
@@ -59,6 +55,25 @@ RSpec.configure do |config|
   # The different available types are documented in the features, such as in
   # https://relishapp.com/rspec/rspec-rails/docs
   config.infer_spec_type_from_file_location!
+
+  config.before(:suite) do
+    DatabaseCleaner.allow_remote_database_url = true
+    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  # "You may want to combine the before(:each) we just added with the
+  # previous one but DON'T. If you combine them, Database Cleaner will
+  # open a transaction before being set to use truncation, which means
+  # Capybara won’t be able to “see” the test database records."
+  # see https://www.devmynd.com/blog/setting-up-rspec-and-capybara-in-rails-5-for-testing/
+  config.before do
+    DatabaseCleaner.start
+  end
+
+  config.after do
+    DatabaseCleaner.clean
+  end
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!

--- a/spec/requests/create_service_spec.rb
+++ b/spec/requests/create_service_spec.rb
@@ -64,6 +64,25 @@ RSpec.describe 'POST /services', type: :request do
     end
   end
 
+  context 'when form name already exists' do
+    let(:params) { { metadata: service } }
+    before do
+      post '/services', params: params, as: :json
+    end
+
+    it 'returns unprocessable entity' do
+      expect(response.status).to be(422)
+    end
+
+    it 'returns an error message' do
+      expect(
+        response_body['message']
+      ).to match_array(
+        ["Name has already been taken"]
+      )
+    end
+  end
+
   context 'when no locale is in the metadata' do
     let(:params) { { metadata: service.reject { |k, _| k == :locale } } }
 

--- a/spec/serialisers/metadata_serialiser_spec.rb
+++ b/spec/serialisers/metadata_serialiser_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MetadataSerialiser do
 
   context '#latest_metadata' do
     it 'metadata should be valid against the base schema' do
-      service = Service.create(service_params)
+      service = Service.create!(service_params)
       serialiser = MetadataSerialiser.new(service, service.latest_metadata)
       expect(serialiser.attributes).to match_schema('service.base')
     end


### PR DESCRIPTION
## Context

We need to validate the uniqueness of the service name in the metadata API.

We had to add database cleaner because the tests were cleaning the DB after each spec which makes the uniqueness fail many times.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>