### PR TITLE
Return user services without using a join

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 UID ?= $(shell id -u)
 DOCKER_COMPOSE = env UID=$(UID) docker-compose -f docker-compose.yml
 
+.PHONY: down
+down:
+	docker-compose down
+
 .PHONY: build
 build:
 	$(DOCKER_COMPOSE) up -d --build metadata-app
@@ -33,7 +37,7 @@ load-test-local: setup
 	cat spec/fixtures/private.pem | base64 | xargs ./bin/load-test
 
 .PHONY: setup
-setup: seed_public_key build
+setup: down seed_public_key build
 
 .PHONY: get_private_key
 get_private_key: setup

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -18,7 +18,7 @@ class ServicesController < ApplicationController
   end
 
   def services_for_user
-    services = Service.joins(:metadata).where("metadata.created_by" => params[:user_id])
+    services = Service.where(created_by: params[:user_id])
 
     render json: ServicesSerializer.new(services).attributes, status: :ok
   end

--- a/spec/requests/get_services_from_user_spec.rb
+++ b/spec/requests/get_services_from_user_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'GET /services/users/:user_id' do
     create(
       :service,
       name: 'Service 1',
+      created_by: 'greedo',
       metadata: [build(:metadata, created_by: 'greedo')]
     )
   end
@@ -11,6 +12,7 @@ RSpec.describe 'GET /services/users/:user_id' do
     create(
       :service,
       name: 'Service 2',
+      created_by: 'han',
       metadata: [build(:metadata, created_by: 'han')]
     )
   end
@@ -18,6 +20,7 @@ RSpec.describe 'GET /services/users/:user_id' do
     create(
       :service,
       name: 'Service 3',
+      created_by: 'greedo',
       metadata: [build(:metadata, created_by: 'greedo')]
     )
   end


### PR DESCRIPTION
## Return user services without using a join

For the moment we are not going to have collaboration between users. So to ease the call on the database, as well as avoiding having to extend the join to make sure only unique services are returned, remove the table join and just use a straight forward query with created_by.

## Down the containers before building

There are some instances where not downing all the containers is a bit problematic when manually testing the editor in the browser