### PR TITLE
Remove acceptance tests services overnight

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,16 @@ jobs:
           success_message: ":rocket:  Successfully deployed to Test  :guitar:"
           failure_message: ":alert:  Failed to deploy to Test  :try_not_to_cry:"
           include_job_number_field: false
+  remove_acceptance_tests_services:
+    working_directory: ~/circle
+    docker:
+      - image: cimg/ruby:2.7.2
+    steps:
+      - checkout
+      - run:
+          name: remove acceptance tests services
+          command: 'bundle exec rake remove_acceptance_tests_services'
+      - slack/status: *slack_status
 
 workflows:
   version: 2
@@ -72,3 +82,13 @@ workflows:
             branches:
               only:
                 - main
+  remove_acceptance_tests_services:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - remove_acceptance_tests_services

--- a/lib/tasks/remove_acceptance_tests_services.rake
+++ b/lib/tasks/remove_acceptance_tests_services.rake
@@ -1,0 +1,15 @@
+desc "
+Remove the services created by acceptance tests
+Usage
+rake remove_acceptance_tests_services
+"
+task :remove_acceptance_tests_services => :environment do |_t, args|
+  services = Service.where("name like ?", "%Acceptance-test-Stormtrooper-FN%")
+  if services.empty?
+    puts 'No services to destroy'
+  else
+    puts "About to destroy #{services.count} services"
+    services.destroy_all
+    puts "Done"
+  end
+end


### PR DESCRIPTION
Currently our acceptance tests do not remove the services that they create when they run. To save RSI from constant scrolling, destroy all the services that the acceptance tests creates every morning.

This is temporary as we will tidy up after each acceptance test run in the future