### PR TITLE
Run acceptance tests cleanup script inside docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,10 @@ jobs:
       - image: cimg/ruby:2.7.2
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: remove acceptance tests services
-          command: 'bundle exec rake remove_acceptance_tests_services'
+          command: docker-compose run --rm metadata-app bundle exec rake remove_acceptance_tests_services
       - slack/status: *slack_status
 
 workflows:


### PR DESCRIPTION
We need to run the rake task to cleanup the acceptance tests services
inside docker in order to have access to the necessary environment
variables