### PR TITLE
Remove acceptance test services every morning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,17 +59,6 @@ jobs:
           success_message: ":rocket:  Successfully deployed to Test  :guitar:"
           failure_message: ":alert:  Failed to deploy to Test  :try_not_to_cry:"
           include_job_number_field: false
-  remove_acceptance_tests_services:
-    working_directory: ~/circle
-    docker:
-      - image: cimg/ruby:2.7.2
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: remove acceptance tests services
-          command: docker-compose run --rm metadata-app bundle exec rake remove_acceptance_tests_services
-      - slack/status: *slack_status
 
 workflows:
   version: 2
@@ -83,13 +72,3 @@ workflows:
             branches:
               only:
                 - main
-  remove_acceptance_tests_services:
-    triggers:
-      - schedule:
-          cron: "0 6 * * *"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - remove_acceptance_tests_services

--- a/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
+++ b/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: fb-metadata-api-cron-remove-acceptance-services-test
+  namespace: formbuilder-saas-test
+spec:
+  schedule: "0 6 * * *"
+  successfulJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: "fb-metadata-api-test"
+            image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-metadata-api:{{ .Values.circleSha1 }}"
+            args:
+            - /bin/sh
+            - -c
+            - bundle exec rails remove_acceptance_tests_services
+            securityContext:
+              runAsUser: 1001
+            imagePullPolicy: Always
+            envFrom:
+              - configMapRef:
+                  name: fb-metadata-api-config-map
+            env:
+              - name: SENTRY_CURRENT_ENV
+                value: test
+              - name: SECRET_KEY_BASE
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-metadata-api-secrets-test
+                    key: secret_key_base
+              - name: ENCODED_PRIVATE_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-metadata-api-secrets-test
+                    key: encoded_private_key
+              - name: DATABASE_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: rds-instance-formbuilder-metadata-api-test
+                    key: url
+              - name: SENTRY_DSN
+                valueFrom:
+                  secretKeyRef:
+                    name: fb-metadata-api-secrets-test
+                    key: sentry_dsn
+          restartPolicy: Never


### PR DESCRIPTION
The job to remove acceptance test services needs to be run from inside kubernetes for it to actually have access to the right database