### PR TITLE
Remove services created by acceptance test user

### DIFF
--- a/lib/tasks/remove_acceptance_tests_services.rake
+++ b/lib/tasks/remove_acceptance_tests_services.rake
@@ -4,7 +4,7 @@ Usage
 rake remove_acceptance_tests_services
 "
 task :remove_acceptance_tests_services => :environment do |_t, args|
-  services = Service.where("name like ?", "%Acceptance-test-Stormtrooper-FN%")
+  services = Service.where(created_by: '1234')
   if services.empty?
     puts 'No services to destroy'
   else


### PR DESCRIPTION
Now that the authentication mechanism is in place users creating a new service are assigned ids specific to them. The user id '1234' is the acceptance test user. We can clear these services every day.