### PR TITLE
Add slack notification for confirming live deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,11 @@ workflows:
             branches:
               only:
                 - main
+      - slack/approval-notification:
+          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
+          include_job_number_field: false
+          requires:
+            - build_and_deploy_to_test
       - confirm_live_deploy:
           type: approval
           requires:


### PR DESCRIPTION
We want the notification for the deployment to the live environment to be sent to slack.