### PR TITLE
Add Sentry Configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'metadata_presenter', '~> 0.19.2'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.3'
-gem 'sentry-raven'
+gem 'sentry-ruby', '~> 4.3.0'
+gem 'sentry-rails', '~> 4.3.1'
 gem 'tzinfo-data'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,9 +80,11 @@ GEM
     factory_bot_rails (6.1.0)
       factory_bot (~> 6.1.0)
       railties (>= 5.0.0)
-    faraday (1.1.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
+    faraday-net_http (1.0.1)
     fb-jwt-auth (0.6.0)
       activesupport
       json
@@ -191,9 +193,17 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
-    ruby2_keywords (0.0.2)
-    sentry-raven (3.1.1)
+    ruby2_keywords (0.0.4)
+    sentry-rails (4.3.1)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
+      concurrent-ruby
+      faraday
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -231,7 +241,8 @@ DEPENDENCIES
   puma (~> 5.2)
   rails (~> 6.1.3)
   rspec-rails
-  sentry-raven
+  sentry-rails (~> 4.3.1)
+  sentry-ruby (~> 4.3.0)
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::API
     MetadataVersionNotFound
   ]
   rescue_from(*NOT_FOUND_EXCEPTIONS) do |exception|
+    Sentry.capture_exception(exception)
     render json: ErrorsSerializer.new(
       message: exception.message
     ).attributes, status: :not_found
@@ -17,6 +18,7 @@ class ApplicationController < ActionController::API
     Fb::Jwt::Auth::TokenExpiredError
   ]
   rescue_from(*FB_JWT_EXCEPTIONS) do |exception|
+    Sentry.capture_exception(exception)
     render json: ErrorsSerializer.new(
       message: exception.message
     ).attributes, status: :forbidden

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,3 +35,13 @@ module FbMetadataApi
     config.api_only = true
   end
 end
+
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger]
+
+  config.before_send = lambda do |event, _hint|
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+    event.request.data = filter.filter(event.request.data)
+    event
+  end
+end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,0 @@
-Raven.configure do |config|
-  config.dsn = ENV['SENTRY_DSN']
-  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
-end

--- a/deploy/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy/fb-metadata-api-chart/templates/deployment.yaml
@@ -42,8 +42,6 @@ spec:
           - configMapRef:
               name: fb-metadata-api-config-map
         env:
-          - name: SENTRY_CURRENT_ENV
-            value: {{ .Values.environmentName }}
           - name: SECRET_KEY_BASE
             valueFrom:
               secretKeyRef:

--- a/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
+++ b/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
@@ -24,8 +24,6 @@ spec:
               - configMapRef:
                   name: fb-metadata-api-config-map
             env:
-              - name: SENTRY_CURRENT_ENV
-                value: {{ .Values.environmentName }}
               - name: SECRET_KEY_BASE
                 valueFrom:
                   secretKeyRef:

--- a/lib/tasks/remove_acceptance_tests_services.rake
+++ b/lib/tasks/remove_acceptance_tests_services.rake
@@ -4,15 +4,19 @@ Usage
 rake remove_acceptance_tests_services
 "
 task :remove_acceptance_tests_services => :environment do |_t, args|
-  if ENV['PLATFORM_ENV'] == test
-    # acceptance tests services are created by the same user during each run
-    services = Service.where(created_by: 'a5833e7a-a210-4447-904c-df050d198e33')
-    if services.empty?
-      puts 'No services to destroy'
-    else
-      puts "About to destroy #{services.count} services"
-      services.destroy_all
-      puts "Done"
+  if ENV['PLATFORM_ENV'] == 'test'
+    begin
+      # acceptance tests services are created by the same user during each run
+      services = Service.where(created_by: 'a5833e7a-a210-4447-904c-df050d198e33')
+      if services.empty?
+        puts 'No services to destroy'
+      else
+        puts "About to destroy #{services.count} services"
+        services.destroy_all
+        puts "Done"
+      end
+    rescue StandardError => e
+      Sentry.capture_exception(e)
     end
   end
 end


### PR DESCRIPTION
## Add Sentry Configuration

SENTRY_DSN environment variable is looked for by default so need to explicitly set it.

This version of sentry uses the config flag send_default_pii to decide sensitive data to be sent. This is set to false by default. This only covers the following:

- user ip address
- user cookie
- request body

Further parameters are filtered in the Sentry configuration.

Capture exception from removal of acceptance test service rake task


## Remove SENTRY_CURRENT_ENV

As a result of having 4 different namespace environments as opposed to the regular 2 we structure our sentry projects differently.

We have 2 sentry projects per app, one for test and one for live. The test one covers anything in the test-dev, test-production and live-dev namespaces whereas live is exclusively for live-production only. Therefore it's fine to let SENTRY_CURRENT_ENV use whatever RAILS_ENV is set to as it does by default.