### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'fb-jwt-auth', '~> 0.6.0'
 gem 'metadata_presenter', '~> 0.19.2'
 gem 'pg', '>= 0.18', '< 2.0'
+gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.2'
 gem 'rails', '~> 6.1.3'
 gem 'sentry-ruby', '~> 4.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     pg (1.2.3)
+    prometheus-client (2.1.0)
     public_suffix (4.0.6)
     puma (5.2.2)
       nio4r (~> 2.0)
@@ -238,6 +239,7 @@ DEPENDENCIES
   httparty
   metadata_presenter (~> 0.19.2)
   pg (>= 0.18, < 2.0)
+  prometheus-client (~> 2.1.0)
   puma (~> 5.2)
   rails (~> 6.1.3)
   rspec-rails

--- a/config.ru
+++ b/config.ru
@@ -2,4 +2,10 @@
 
 require_relative 'config/environment'
 
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
+
 run Rails.application


### PR DESCRIPTION
Cloud Platform uses Prometheus to surface metrics about apps. This adds the necessary rack middlewares to aid this process.

Currently it will not really provide much useful data, but for now it will at least silence the continuous 404's that Sentry is receiving.