### PR TITLE
Set platform environment in container

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy/fb-metadata-api-chart/templates/deployment.yaml
@@ -70,6 +70,8 @@ spec:
               secretKeyRef:
                 name: fb-metadata-api-secrets-{{ .Values.environmentName }}
                 key: sentry_dsn
+          - name: PLATFORM_ENV
+            value: {{ .Values.environmentName }}
       volumes:
         - name: tmp-files
           emptyDir: {}


### PR DESCRIPTION
PLATFORM_ENV was only used by circle during deployment but not actually
injected into the containers.

It is required for the overnight cleanup task that removes acceptance
tests services. We only want it to run in the test environment.