### PR TITLE
Add label to acceptance test cronjob

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
+++ b/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
@@ -5,10 +5,13 @@ metadata:
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   schedule: "0 6 * * *"
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:
+        metadata:
+          labels:
+            remove-acceptance-tests-services: cronjob
         spec:
           containers:
           - name: "fb-metadata-api-{{ .Values.environmentName }}"


### PR DESCRIPTION
Just to make it a little easier to check for the status of completed
cronjobs add a label to the metatdata. Should then be possible to do
something like:

`kubectl get pods -n formbuilder-saas-test -l remove-acceptance-tests-services`

Also bump the successful job history to 1.