### PR TITLE
Deny access to metrics entrypoint

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/ingress.yaml
+++ b/deploy/fb-metadata-api-chart/templates/ingress.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: "fb-metadata-api-ing-{{ .Values.environmentName }}"
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      server_tokens off;
+      location /metrics {
+        deny all;
+        return 401;
+      }


### PR DESCRIPTION
We do not want unauthorised access to the metrics endpoint. There is no need for the request to even get as far as the application.

Prometheus seems to go directly to the container instead of using the ingress.