### PR TITLE
Add platform environment to cronjob

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
+++ b/deploy/fb-metadata-api-chart/templates/remove_test_services.yaml
@@ -47,4 +47,6 @@ spec:
                   secretKeyRef:
                     name: fb-metadata-api-secrets-{{ .Values.environmentName }}
                     key: sentry_dsn
+              - name: PLATFORM_ENV
+                value: {{ .Values.environmentName }}
           restartPolicy: Never


### PR DESCRIPTION
The rake task that removes the acceptance tests requires the platform
environment during its run.