### PR TITLE
Increase initialDelaySeconds

### DIFF
--- a/deploy/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy/fb-metadata-api-chart/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 5
+          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
         # non-secret env vars


### PR DESCRIPTION
This will mean that Kubernetes waits a little longer before attempting
to check the health of the container.

This may or may not help when it comes to failing connections to the
metadata api while the containers are being restarted