### PR TITLE
Rake task to check service flow object creation

### DIFF
--- a/lib/tasks/check_service_flow_objects.rake
+++ b/lib/tasks/check_service_flow_objects.rake
@@ -1,0 +1,41 @@
+desc "
+Checks the services have correctly migrated to using the flow objects
+Usage
+rake check_service_flow_objects
+"
+task check_service_flow_objects: :environment do |_t, _args|
+  result = %i[with without to_check].index_with { |_key| [] }
+  services = Service.all
+  services.each do |service|
+    id_and_name = "#{service.id} => #{service.name}"
+    metadata = service.latest_metadata.data
+    if metadata['flow'].present?
+      no_flow_object_for_page = metadata['pages'].any? do |page|
+        metadata['flow'][page['_uuid']].blank?
+      end
+
+      incorrect_next_page = metadata['pages'].each_with_index.any? do |page, index|
+        default_next = metadata['flow'][page['_uuid']]['next']['default']
+        next_uuid = page == metadata['pages'].last ? '' : metadata['pages'][index + 1]['_uuid']
+        default_next != next_uuid
+      end
+
+      if no_flow_object_for_page || incorrect_next_page
+        result[:to_check].push(id_and_name)
+      else
+        result[:with].push(id_and_name)
+      end
+    else
+      result[:without].push(id_and_name)
+    end
+  end
+
+  puts "Services with flow objects:\n"
+  puts result[:with].join("\n")
+
+  puts "\nServices without flow objects:\n"
+  puts result[:without].join("\n")
+
+  puts "\nServices to check:\n"
+  puts result[:to_check].join("\n")
+end


### PR DESCRIPTION
The service flow objects should be created automatically when a user
visits the flow page for their service.

This tasks checks that each service has had a flow object created and
that it is correct.

Since there is no branching at this time each flow object should link to
the next page at the correct index in the pages array except for the
last page which should just be an empty string