### PR TITLE
Run Editor Acceptance tests after deploying to Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
+  browser-tools: circleci/browser-tools@1.1.3
 
 jobs:
   test:
@@ -95,6 +96,49 @@ jobs:
           success_message: ":rocket:  Successfully deployed to Live  :guitar:"
           failure_message: ":alert:  Failed to deploy to Live  :try_not_to_cry:"
           include_job_number_field: false
+  editor_acceptance_tests:
+    docker:
+      - image: cimg/ruby:2.7.3
+      - environment:
+          POSTGRES_DB: editor_local
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: postgres
+        image: 'circleci/postgres:12.4'
+    resource_class: large
+    environment:
+      BUNDLE_JOBS: '3'
+      BUNDLE_RETRY: '3'
+      PGHOST: 127.0.0.1
+      PGPASSWORD: password
+      PGUSER: postgres
+      RAILS_ENV: test
+    parallelism: 3
+    steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - run:
+          name: Run editor acceptance tests
+          environment:
+            ACCEPTANCE_TESTS_EDITOR_APP: 'https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/'
+            CI_MODE: 'true'
+          command: |
+            EDITOR_APP=https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk
+            echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
+            echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
+            echo 'export CI_MODE=true' >> $BASH_ENV
+            source $BASH_ENV
+
+            git clone https://github.com/ministryofjustice/fb-editor
+            cd fb-editor
+
+            bundle install
+            bundle exec rails db:setup
+            bundle exec rails db:migrate
+
+            TESTFILES=$(circleci tests glob "project/fb-editor/acceptance/**/*_spec.rb" | circleci tests split --split-by=name)
+            bundle exec rspec acceptance $TESTFILES --profile 10 -f doc
+      - slack/status: *slack_status
 
 workflows:
   version: 2
@@ -108,15 +152,18 @@ workflows:
             branches:
               only:
                 - main
+      - editor_acceptance_tests:
+          requires:
+            - build_and_deploy_to_test
       - slack/approval-notification:
           message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
           include_job_number_field: false
           requires:
-            - build_and_deploy_to_test
+            - editor_acceptance_tests
       - confirm_live_deploy:
           type: approval
           requires:
-            - build_and_deploy_to_test
+            - editor_acceptance_tests
       - build_and_deploy_to_live:
           requires:
             - confirm_live_deploy


### PR DESCRIPTION
Changes to the metadata api can also affect the functionality of the
editor. Run the editor acceptance tests after deploying to test.

Unfortunately this does add about 7 minutes onto the deploy time.