### PR TITLE
Create service flow objects rake task

### DIFF
--- a/lib/tasks/create_service_flow_objects.rake
+++ b/lib/tasks/create_service_flow_objects.rake
@@ -1,0 +1,39 @@
+desc "
+Creates the service flow objects from the pages array
+Usage
+rake create_service_flow_objects
+"
+task create_service_flow_objects: :environment do |_t, _args|
+  require_relative 'new_flow_page_generator'
+
+  services = Service.all
+  services.each do |service|
+    latest_metadata = service.latest_metadata
+    metadata = latest_metadata.data
+
+    next if metadata['flow'].present?
+
+    puts "Creating service flow for #{service.id} => #{service.name}\n"
+    service_flow = metadata['pages'].each_with_index.inject({}) do |hash, (page, index)|
+      hash.merge(
+        NewFlowPageGenerator.new(
+          page_uuid: page['_uuid'],
+          page_index: index,
+          latest_metadata: metadata
+        ).to_metadata
+      )
+    end
+
+    begin
+      if MetadataPresenter::ValidateSchema.validate(service_flow, 'flow.base')
+        metadata['flow'] = service_flow
+        metadata['pages'][0] = metadata['pages'][0].except('steps')
+        latest_metadata.data = metadata
+        latest_metadata.save!
+      end
+    rescue StandardError => e
+      puts "Failed to create service flow for #{service.id} => #{service.name}\n"
+      puts e.message
+    end
+  end
+end

--- a/lib/tasks/new_flow_page_generator.rb
+++ b/lib/tasks/new_flow_page_generator.rb
@@ -1,0 +1,42 @@
+class NewFlowPageGenerator
+  def initialize(page_uuid:, page_index:, latest_metadata:)
+    @page_uuid = page_uuid
+    @page_index = page_index
+    @latest_metadata = latest_metadata
+  end
+
+  def to_metadata
+    { page_uuid => flow_page_metadata }
+  end
+
+  private
+
+  attr_reader :page_uuid, :page_index, :latest_metadata
+
+  def flow_page_metadata
+    flow_page = default_metadata
+    flow_page['next']['default'] = default_next
+    flow_page
+  end
+
+  def default_next
+    next_page.present? ? next_page['_uuid'] : ''
+  end
+
+  def next_page
+    @next_page ||= begin
+      return if page_index.nil?
+
+      latest_metadata['pages'][page_index + 1]
+    end
+  end
+
+  def default_metadata
+    {
+      '_type' => 'flow.page',
+      'next' => {
+        'default' => ''
+      }
+    }
+  end
+end


### PR DESCRIPTION
Older services made use of the pages array their flow as since there was
no conditional logic the editor and runner would just traverse the array
in order.

The runner is backwards compatible and will make use of either flow
objects or an array of page objects.

This adds a task to create the flow objects from the pages
array for services that do not already use the flow objects.

There is already a before_action in the editor to do this for any user
that visits the flow page for their form. This task is a backup for
that.