### PR TITLE
Bump to version 2.3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.7.3'
 
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'fb-jwt-auth', '~> 0.7.0'
-gem 'metadata_presenter', '~> 2.3.1'
+gem 'metadata_presenter', '~> 2.3.2'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.1)
-    metadata_presenter (2.3.1)
+    metadata_presenter (2.3.2)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (>= 2.8.1)
       kramdown (>= 2.3.0)
@@ -285,7 +285,7 @@ DEPENDENCIES
   factory_bot_rails
   fb-jwt-auth (~> 0.7.0)
   httparty
-  metadata_presenter (~> 2.3.1)
+  metadata_presenter (~> 2.3.2)
   pg (>= 0.18, < 2.0)
   prometheus-client (~> 2.1.0)
   puma (~> 5.4)


### PR DESCRIPTION
Version 2.3.2 removes the lede from the start page

Relates to [this PR](https://github.com/ministryofjustice/fb-metadata-presenter/pull/170)