### PR TITLE
Increase parallelism for acceptance test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       PGPASSWORD: password
       PGUSER: postgres
       RAILS_ENV: test
-    parallelism: 3
+    parallelism: 4
     steps:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
@@ -136,8 +136,17 @@ jobs:
             bundle exec rails db:setup
             bundle exec rails db:migrate
 
-            TESTFILES=$(circleci tests glob "project/fb-editor/acceptance/**/*_spec.rb" | circleci tests split --split-by=name)
-            bundle exec rspec acceptance $TESTFILES --profile 10 -f doc
+            TESTFILES=$(circleci tests glob "acceptance/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
+            echo '***********'
+            echo $TESTFILES
+            echo '***********'
+
+            bundle exec rspec --format progress \
+              --format RspecJunitFormatter \
+              --out ~/acceptance/acceptance.xml \
+              $TESTFILES
+      - store_test_results:
+          path: ~/acceptance
       - slack/status: *slack_status
 
 workflows:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'database_cleaner-active_record'
   gem 'factory_bot_rails'
   gem 'httparty'
+  gem 'rspec_junit_formatter'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    rspec_junit_formatter (0.4.1)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.15.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -291,6 +293,7 @@ DEPENDENCIES
   puma (~> 5.4)
   rails (~> 6.1.4)
   rspec-rails
+  rspec_junit_formatter
   rubocop (~> 1.15.0)
   rubocop-govuk
   sentry-rails (~> 4.6.5)


### PR DESCRIPTION
The acceptance tests will now be split across those 4 processes by
historical test run timing data which is uploaded and stored by CircleCi
after each run.