### PR TITLE
Update browser tools orb and install all browser tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-  browser-tools: circleci/browser-tools@1.1.3
+  browser-tools: circleci/browser-tools@1.2.1
 
 jobs:
   test:
@@ -114,13 +114,14 @@ jobs:
       RAILS_ENV: test
     parallelism: 4
     steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
+      - browser-tools/install-browser-tools
+      - run:
+          name: Check browser tools install
+          command: |
+            google-chrome --version
+            chromedriver --version
       - run:
           name: Run editor acceptance tests
-          environment:
-            ACCEPTANCE_TESTS_EDITOR_APP: 'https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk/'
-            CI_MODE: 'true'
           command: |
             EDITOR_APP=https://fb-editor-test.apps.live-1.cloud-platform.service.justice.gov.uk
             echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV


### PR DESCRIPTION
Swap to install all the browser tools as install-chrome by itself is
broken.

There is an open PR to resolve this issue. In the meantime just install
all the things.

CircleCI-Public/browser-tools-orb#33

Also remove setting the ACCEPTANCE_TESTS_EDITOR_APP and CI_MODE environment
variables in their own step as they are set inside the command below.