### PR TITLE
Add uuid to items rake task

### DIFF
--- a/lib/tasks/add_uuid_to_items.rake
+++ b/lib/tasks/add_uuid_to_items.rake
@@ -1,0 +1,31 @@
+desc "
+Add UUIDs to items in latest metadata
+Usage
+rake add_uuid_to_items
+"
+task add_uuid_to_items: :environment do |_t, _args|
+  ActiveRecord::Base.logger = Logger.new($stdout)
+
+  Service.all.each do |service|
+    latest_metadata = service.latest_metadata
+    data = latest_metadata.try(:data)
+
+    next if data.blank?
+
+    data['pages'].each do |page|
+      Array(page['components']).each do |component|
+        Array(component['items']) do |item|
+          if item['_uuid'].blank?
+            item['_uuid'] = SecureRandom.uuid
+          end
+        end
+      end
+    end
+
+    service.metadata.create!(
+      data: data,
+      locale: latest_metadata.locale,
+      created_by: latest_metadata.created_by
+    )
+  end
+end


### PR DESCRIPTION
We found out that all items that users are adding doesn't have
the UUIDs being generated so we need to generate one UUID in
case the item doesn't have to use in branching expressions.