### PR TITLE
Add total services count in the services API

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -4,7 +4,7 @@ class ServicesController < ApplicationController
   def index
     services = Service.order(name: :asc).page(page).per(per_page)
 
-    render json: ServicesSerializer.new(services).attributes
+    render json: ServicesSerializer.new(services, total_services: true).attributes
   end
 
   def create

--- a/app/serialisers/services_serializer.rb
+++ b/app/serialisers/services_serializer.rb
@@ -1,8 +1,9 @@
 class ServicesSerializer
-  attr_reader :services
+  attr_reader :services, :total_services
 
-  def initialize(services)
+  def initialize(services, total_services: false)
     @services = services
+    @total_services = total_services
   end
 
   def attributes
@@ -12,7 +13,10 @@ class ServicesSerializer
         service_name: service.name
       }
     end
+    response = { services: all_services }
 
-    { services: all_services }
+    response.tap do
+      response[:total_services] = Service.count if total_services.present?
+    end
   end
 end

--- a/spec/requests/get_services_spec.rb
+++ b/spec/requests/get_services_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe 'GET /services' do
       expect(response.status).to eq(200)
     end
 
+    it 'returns the total services' do
+      expect(response_body['total_services']).to be(3)
+    end
+
     it 'returns all services' do
       expect(response_body['services']).to match_array(
         [
@@ -70,6 +74,10 @@ RSpec.describe 'GET /services' do
         expect(response.status).to eq(200)
       end
 
+      it 'returns the total services' do
+        expect(response_body['total_services']).to be(3)
+      end
+
       it 'returns the number of services in the per page param' do
         expect(response_body['services']).to match_array(
           [
@@ -87,6 +95,10 @@ RSpec.describe 'GET /services' do
 
       it 'returns success response' do
         expect(response.status).to eq(200)
+      end
+
+      it 'returns the total services' do
+        expect(response_body['total_services']).to be(3)
       end
 
       it 'returns the number of services in the per page param' do


### PR DESCRIPTION
In case the client needs to do pagination this information is required to mount the total pages to show in the pagination.

Only show the total services in /services.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>