### PR TITLE
Increase parallelism for editor acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
       PGPASSWORD: password
       PGUSER: postgres
       RAILS_ENV: test
-    parallelism: 4
+    parallelism: 5
     steps:
       - browser-tools/install-browser-tools
       - run:


### PR DESCRIPTION
Bump the number of parallel pods to 5 as we have a lot of acceptance
tests now