### PR TITLE
Use browser tools 1.2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
-  browser-tools: circleci/browser-tools@1.2.1
+  browser-tools: circleci/browser-tools@1.2.4
 
 jobs:
   test:
@@ -121,7 +121,8 @@ jobs:
       RAILS_ENV: test
     parallelism: 5
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install
           command: |


### PR DESCRIPTION
Update the browser tools to 1.2.4.

Also only install chrome and chromedriver as we do not need firefox and
geckodriver