### PR TITLE
Horizontal autoscaling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,39 @@
 version: 2.1
 orbs:
+  ruby: circleci/ruby@1.4.0
   slack: circleci/slack@3.4.2
   browser-tools: circleci/browser-tools@1.2.4
 
 jobs:
+  build:
+    docker:
+      - image: 'cimg/ruby:2.7.5'
+    steps:
+      - checkout
+      - ruby/install-deps
+      - slack/status: &slack_status
+          fail_only: true
+          only_for_branches: main
+          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
+          include_job_number_field: false
+  lint:
+    docker:
+      - image: 'cimg/ruby:2.7.5'
+    steps:
+      - checkout
+      - ruby/install-deps
+      - ruby/rubocop-check:
+          format: progress
+          label: running rubocop
+      - slack/status: *slack_status
+  security:
+    docker:
+      - image: 'cimg/ruby:2.7.5'
+    steps:
+      - checkout
+      - ruby/install-deps
+      - run: bundle exec brakeman -q --no-pager
+      - slack/status: *slack_status
   test:
     working_directory: ~/circle
     docker:
@@ -11,7 +41,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 19.03.13
+          version: 20.10.11
       - run:
           name: Install Docker Compose
           command: |
@@ -19,20 +49,10 @@ jobs:
             chmod +x ~/docker-compose
             sudo mv ~/docker-compose /usr/local/bin/docker-compose
       - run:
-         name: security
-         command: docker-compose run --rm metadata-app bundle exec brakeman -q --no-pager
-      - run:
-          name: lint
-          command: docker-compose run --rm metadata-app bundle exec rubocop
-      - run:
           name: test
           command: make spec
-      - slack/status: &slack_status
-          fail_only: true
-          only_for_branches: main
-          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
-          include_job_number_field: false
-  build_and_deploy_to_test:
+      - slack/status: *slack_status
+  build_and_push_image:
     working_directory: ~/circle/git/fb-metadata-api
     docker: &ecr_image
       - image: $AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
@@ -41,10 +61,8 @@ jobs:
           aws_secret_access_key: $AWS_BUILD_IMAGE_SECRET_ACCESS_KEY
     steps:
       - checkout
-      - setup_remote_docker
-      - add_ssh_keys: &ssh_keys
-          fingerprints:
-            - a9:9c:0f:a2:2f:77:41:80:b8:84:e0:c8:10:a4:eb:2e
+      - setup_remote_docker:
+          version: 20.10.11
       - run: &base_environment_variables
           name: Setup base environment variable
           command: |
@@ -58,6 +76,18 @@ jobs:
           environment:
             ENVIRONMENT_NAME: test
           command: './deploy-scripts/bin/build'
+  deploy_to_test:
+    working_directory: ~/circle/git/fb-metadata-api
+    docker: *ecr_image
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.11
+      - add_ssh_keys: &ssh_keys
+          fingerprints:
+            - a9:9c:0f:a2:2f:77:41:80:b8:84:e0:c8:10:a4:eb:2e
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: deploy to test
           environment:
@@ -72,25 +102,35 @@ jobs:
             PLATFORM_ENV: test
             K8S_NAMESPACE: formbuilder-saas-test
           command: './deploy-scripts/bin/deploy-eks'
-      - slack/status:
-          only_for_branches: main
-          success_message: ":rocket:  Successfully deployed to Test  :guitar:"
-          failure_message: ":alert:  Failed to deploy to Test  :try_not_to_cry:"
-          include_job_number_field: false
-  build_and_deploy_to_live:
+      - slack/status: *slack_status
+  deploy_to_test_eks:
     working_directory: ~/circle/git/fb-metadata-api
     docker: *ecr_image
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 20.10.11
       - add_ssh_keys: *ssh_keys
       - run: *base_environment_variables
       - run: *deploy_scripts
       - run:
-          name: build and push docker images
+          name: deploy to test environment in EKS
           environment:
-            ENVIRONMENT_NAME: live
-          command: './deploy-scripts/bin/build'
+            APPLICATION_NAME: fb-metadata-api
+            PLATFORM_ENV: test
+            K8S_NAMESPACE: formbuilder-saas-test
+          command: './deploy-scripts/bin/deploy-eks'
+      - slack/status: *slack_status
+  deploy_to_live:
+    working_directory: ~/circle/git/fb-metadata-api
+    docker: *ecr_image
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.11
+      - add_ssh_keys: *ssh_keys
+      - run: *base_environment_variables
+      - run: *deploy_scripts
       - run:
           name: deploy to live
           environment:
@@ -199,20 +239,35 @@ workflows:
   version: 2
   test_and_build:
     jobs:
-      - test
-      - build_and_deploy_to_test:
+      - build
+      - lint:
           requires:
+            - build
+      - security:
+          requires:
+            - build
+      - test
+      - build_and_push_image:
+          requires:
+            - lint
+            - security
             - test
           filters:
             branches:
               only:
                 - main
+      - deploy_to_test:
+          requires:
+            - build_and_push_image
+      - deploy_to_test_eks:
+          requires:
+            - build_and_push_image
       - editor_acceptance_tests:
           requires:
-            - build_and_deploy_to_test
+            - deploy_to_test
       - editor_acceptance_tests_no_branching:
           requires:
-            - build_and_deploy_to_test
+            - deploy_to_test
       - slack/approval-notification:
           message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
           include_job_number_field: false
@@ -224,6 +279,6 @@ workflows:
           requires:
             - editor_acceptance_tests
             - editor_acceptance_tests_no_branching
-      - build_and_deploy_to_live:
+      - deploy_to_live:
           requires:
             - confirm_live_deploy

--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -2,4 +2,10 @@ class HealthController < ActionController::API
   def show
     render plain: 'healthy'
   end
+
+  def readiness
+    if ActiveRecord::Base.connection && ActiveRecord::Base.connected?
+      render plain: 'ready'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-  get '/health', to: 'health#show'
+  get '/health', to: 'health#show' # used for liveness probe
+  get '/readiness', to: 'health#readiness'
 
   resources :services, only: [:index, :create] do
     get '/users/:user_id', to: 'services#services_for_user', on: :collection

--- a/deploy-eks/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-metadata-api-chart/templates/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   replicas: {{ .Values.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.strategy.maxSurge }}
+      maxUnavailable: {{ .Values.strategy.maxUnavailable }}
   selector:
     matchLabels:
       app: "fb-metadata-api-{{ .Values.environmentName }}"

--- a/deploy-eks/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-metadata-api-chart/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "fb-metadata-api-{{ .Values.environmentName }}"
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
-  replicas: 2
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: "fb-metadata-api-{{ .Values.environmentName }}"
@@ -29,13 +29,20 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
-        readinessProbe:
+        livenessProbe:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 3000
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:

--- a/deploy-eks/fb-metadata-api-chart/templates/hpa.yaml
+++ b/deploy-eks/fb-metadata-api-chart/templates/hpa.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.hpa }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: fb-metadata-api-{{ .Values.environmentName }}
+  namespace: formbuilder-saas-{{ .Values.environmentName }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: fb-metadata-api-{{ .Values.environmentName }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy/fb-metadata-api-chart/templates/deployment.yaml
@@ -7,6 +7,11 @@ metadata:
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
   replicas: {{ .Values.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: {{ .Values.strategy.maxSurge }}
+      maxUnavailable: {{ .Values.strategy.maxUnavailable }}
   selector:
     matchLabels:
       app: "fb-metadata-api-{{ .Values.environmentName }}"

--- a/deploy/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy/fb-metadata-api-chart/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: "fb-metadata-api-{{ .Values.environmentName }}"
   namespace: formbuilder-saas-{{ .Values.environmentName }}
 spec:
-  replicas: 2
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: "fb-metadata-api-{{ .Values.environmentName }}"
@@ -29,13 +29,20 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 3000
-        readinessProbe:
+        livenessProbe:
           httpGet:
             path: /health
             port: 3000
-          initialDelaySeconds: 15
-          periodSeconds: 5
-          successThreshold: 1
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 3000
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
         # non-secret env vars
         # defined in config_map.yaml
         envFrom:


### PR DESCRIPTION
## Add readiness probe endpoint

Add readiness endpoint to check connection to database before allowing traffic to the container

## Use config from deploy repo

Use the fb-metadata-api-deploy repo to set configuration options
 
## Add RollingUpdate strategy

Create a rolling update strategy for deployment
 
## Add horizontal scaling configuration

Adds horizontal scaling configuration for the EKS cluster. Unfortunately we are no longer able to make any changes to the old cluster. HPA was added manually to that cluster.
 
## Update circleci config

Parallelise deployements

![Screenshot 2022-02-15 at 14 45 39](https://user-images.githubusercontent.com/3466862/154240754-4418039d-2396-4bee-af1b-8af1fb1ddf87.png)

