### PR TITLE
Ignore concurrent migrations when deploying

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ EXPOSE $APP_PORT
 USER ${UID}
 
 ARG RAILS_ENV=production
-CMD bundle exec rake db:migrate && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0
+CMD bundle exec rake db:migrate:ignore_concurrent && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0

--- a/lib/tasks/migrate_ignore_concurrent.rake
+++ b/lib/tasks/migrate_ignore_concurrent.rake
@@ -1,0 +1,15 @@
+namespace :db do
+  namespace :migrate do
+    desc 'Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors'
+    task ignore_concurrent: :environment do
+      # DB migrations are called as the entry command in the Dockerfile
+      # Since we have multiple pods for the Metadata API we only need the first
+      # migration to run and any proceeding ActiveRecord::ConcurrentMigrationError
+      # can rescued instead of sending a Sentry alert.
+
+      Rake::Task['db:migrate'].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Move along
+    end
+  end
+end


### PR DESCRIPTION
We call the db migrations rake task in the dockerfile. Since we have
multiple pods starting up at the same time this means it gets called
more than once.

To stop the concurrent migrations error being thrown unecessarily add
another rake task and catch the error and ignore.