### PR TITLE
Add Inflection for Items model

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -5,6 +5,7 @@
 # locales as you wish. All of these examples are active by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular 'metadata', 'metadata'
+  inflect.irregular 'items', 'items'
 #   inflect.plural /^(ox)$/i, '\1en'
 #   inflect.singular /^(ox)en/i, '\1'
 #   inflect.irregular 'person', 'people'


### PR DESCRIPTION
Rails attempts to use singular `Item` when initialising the constant `Service::Item`, causing errors when attempting to delete Service records.
Add an inflection to by pass this default, thereby initialising the constant as `Service::Items`.
