### PR TITLE
Autocomplete POST Endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.7.5'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'fb-jwt-auth', '~> 0.8.0'
 gem 'kaminari'
-gem 'metadata_presenter', '~> 2.17.1'
+gem 'metadata_presenter', '~> 2.17.3'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 5.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
-    metadata_presenter (2.17.1)
+    metadata_presenter (2.17.3)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
       kramdown (>= 2.3.0)
@@ -277,7 +277,7 @@ DEPENDENCIES
   fb-jwt-auth (~> 0.8.0)
   httparty
   kaminari
-  metadata_presenter (~> 2.17.1)
+  metadata_presenter (~> 2.17.3)
   pg (>= 0.18, < 2.0)
   prometheus-client (~> 2.1.0)
   puma (~> 5.6)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,6 @@ class ApplicationController < ActionController::API
   end
 
   before_action AuthenticateApplication
-  before_action MetadataPresenter::ValidateSchema
 
   def not_found
     render json: ErrorsSerializer.new(

--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -1,14 +1,11 @@
 class ComponentItemsController < ApplicationController
   def index
-    render json: ComponentItemsSerialiser.new(items, service).attributes, status: :ok
+    render json: ComponentItemsSerialiser.new(service.items, service).attributes, status: :ok
   end
 
   def create
     if new_items.save
-      render(
-        json: ComponentItemsSerialiser.new(items, service).attributes,
-        status: :created
-      )
+      render(status: :created)
     else
       render json: ErrorsSerializer.new(
         message: service.errors.full_messages
@@ -18,32 +15,11 @@ class ComponentItemsController < ApplicationController
 
   private
 
-  def items
-    @items ||= Items.where(service_id: service.id)
-  end
-
   def new_items
     @new_items ||= Items.new(items_params)
   end
 
   def items_params
-    params.permit(:metadata)
-    attributes = params[:metadata]
-
-    if attributes
-      {
-        service_id: attributes[:service_id],
-        component_id: params[:component_id],
-        created_by: attributes[:created_by],
-        data: attributes[:data]
-      }
-    else
-      {
-        service_id: nil,
-        component_id: nil,
-        created_by: nil,
-        data: [{}]
-      }
-    end
+    params.permit(:service_id, :component_id, :created_by, data: %i[text value])
   end
 end

--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -1,4 +1,6 @@
 class ComponentItemsController < ApplicationController
+  before_action :validate_items, only: :create
+
   def index
     render json: ComponentItemsSerialiser.new(service.items, service).attributes, status: :ok
   end
@@ -21,5 +23,14 @@ class ComponentItemsController < ApplicationController
 
   def items_params
     params.permit(:service_id, :component_id, :created_by, data: %i[text value])
+  end
+
+  def validate_items
+    MetadataPresenter::ValidateSchema.validate(params[:data], 'definition.select')
+  rescue JSON::Schema::ValidationError, JSON::Schema::SchemaError, SchemaNotFoundError => e
+    render(
+      json: ErrorsSerializer.new(message: e.message).attributes,
+      status: :unprocessable_entity
+    )
   end
 end

--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -3,9 +3,47 @@ class ComponentItemsController < ApplicationController
     render json: ComponentItemsSerialiser.new(items, service).attributes, status: :ok
   end
 
+  def create
+    if new_items.save
+      render(
+        json: ComponentItemsSerialiser.new(items, service).attributes,
+        status: :created
+      )
+    else
+      render json: ErrorsSerializer.new(
+        message: service.errors.full_messages
+      ).attributes, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def items
     @items ||= Items.where(service_id: service.id)
+  end
+
+  def new_items
+    @new_items ||= Items.new(items_params)
+  end
+
+  def items_params
+    params.permit(:metadata)
+    attributes = params[:metadata]
+
+    if attributes
+      {
+        service_id: attributes[:service_id],
+        component_id: params[:component_id],
+        created_by: attributes[:created_by],
+        data: attributes[:data]
+      }
+    else
+      {
+        service_id: nil,
+        component_id: nil,
+        created_by: nil,
+        data: [{}]
+      }
+    end
   end
 end

--- a/app/controllers/metadata_controller.rb
+++ b/app/controllers/metadata_controller.rb
@@ -1,0 +1,3 @@
+class MetadataController < ApplicationController
+  before_action MetadataPresenter::ValidateSchema
+end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,4 +1,4 @@
-class ServicesController < ApplicationController
+class ServicesController < MetadataController
   SERVICE_EXISTS = 'Name has already been taken'.freeze
 
   def index

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -1,4 +1,4 @@
-class VersionsController < ApplicationController
+class VersionsController < MetadataController
   def create
     if service.update(service_params)
       metadata = service.latest_metadata

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     end
 
     get '/items/all', as: :items, to: 'component_items#index'
+    post 'components/:component_id/items/all', to: 'component_items#create'
   end
 
   match '*unmatched', to: 'application#not_found', via: :all

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -105,26 +105,47 @@ RSpec.describe 'API integration tests' do
     end
 
     context 'when new items are created' do
-      it 'returns the newly created items for that service' do
-        response = metadata_api_test_client.create_service(
-          body: request_body,
-          authorisation_headers: authorisation_headers
-        )
-        metadata = parse_response(response)
+      context 'when schema is valid' do
+        it 'returns the newly created items for that service' do
+          response = metadata_api_test_client.create_service(
+            body: request_body,
+            authorisation_headers: authorisation_headers
+          )
+          metadata = parse_response(response)
 
-        updated_payload = items_one.merge(
-          created_by: metadata[:created_by],
-          service_id: metadata[:service_id]
-        )
+          updated_payload = items_one.merge(
+            created_by: metadata[:created_by],
+            service_id: metadata[:service_id]
+          )
 
-        response = metadata_api_test_client.create_items(
-          service_id: metadata[:service_id],
-          component_id: items_one[:component_id],
-          body: updated_payload.to_json,
-          authorisation_headers: authorisation_headers
-        )
+          response = metadata_api_test_client.create_items(
+            service_id: metadata[:service_id],
+            component_id: items_one[:component_id],
+            body: updated_payload.to_json,
+            authorisation_headers: authorisation_headers
+          )
 
-        expect(response.code).to be(201)
+          expect(response.code).to be(201)
+        end
+      end
+
+      context 'when schema is not valid' do
+        it 'returns a 422' do
+          response = metadata_api_test_client.create_service(
+            body: request_body,
+            authorisation_headers: authorisation_headers
+          )
+          metadata = parse_response(response)
+
+          response = metadata_api_test_client.create_items(
+            service_id: metadata[:service_id],
+            component_id: items_one[:component_id],
+            body: {},
+            authorisation_headers: authorisation_headers
+          )
+
+          expect(response.code).to be(422)
+        end
       end
     end
 

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -30,6 +30,26 @@ RSpec.describe 'API integration tests' do
     ).deep_symbolize_keys
   end
   let(:request_body) { { "metadata": service }.to_json }
+  let(:component_id_one) { 'b27cb47a-95cf-44d8-be2b-75b2411c2188' }
+  let(:items_one) do
+    {
+      component_id: component_id_one,
+      data: [
+        {
+          "text": 'foo',
+          "value": 'bar'
+        },
+        {
+          "text": '123',
+          "value": 'abc'
+        },
+        {
+          "text": 'qweq',
+          "value": '0976'
+        }
+      ]
+    }
+  end
 
   def parse_response(response)
     JSON.parse(response.body, symbolize_names: true)
@@ -81,6 +101,104 @@ RSpec.describe 'API integration tests' do
         updated_metadata = parse_response(response)
         expect(response.code).to be(201)
         expect(updated_metadata).to include(pages: version[:pages])
+      end
+    end
+
+    context 'when new items are created' do
+      it 'returns the newly created items for that service' do
+        response = metadata_api_test_client.create_service(
+          body: request_body,
+          authorisation_headers: authorisation_headers
+        )
+        metadata = parse_response(response)
+
+        updated_payload = items_one.merge(
+          created_by: metadata[:created_by],
+          service_id: metadata[:service_id]
+        )
+
+        response = metadata_api_test_client.create_items(
+          service_id: metadata[:service_id],
+          component_id: items_one[:component_id],
+          body: updated_payload.to_json,
+          authorisation_headers: authorisation_headers
+        )
+
+        expect(response.code).to be(201)
+      end
+    end
+
+    context 'getting all items for a service' do
+      let(:component_id_two) { '1c6bef50-d2a5-4c59-b4f9-8bb4667b3647' }
+      let(:items_two) do
+        {
+          component_id: component_id_two,
+          data: [
+            {
+              "text": 'cat',
+              "value": '100'
+            },
+            {
+              "text": 'dog',
+              "value": '200'
+            }
+          ]
+        }
+      end
+      let(:expected_response) do
+        [
+          {
+            "b27cb47a-95cf-44d8-be2b-75b2411c2188": [
+              { text: 'foo', value: 'bar' },
+              { text: '123', value: 'abc' },
+              { text: 'qweq', value: '0976' }
+            ]
+          },
+          {
+            "1c6bef50-d2a5-4c59-b4f9-8bb4667b3647": [
+              { text: 'cat', value: '100' },
+              { text: 'dog', value: '200' }
+            ]
+          }
+        ]
+      end
+      let(:hash) do
+        Hash[
+          component_id_one => items_one,
+          component_id_two => items_two
+        ]
+      end
+
+      it 'it should return all the items for that service' do
+        response = metadata_api_test_client.create_service(
+          body: request_body,
+          authorisation_headers: authorisation_headers
+        )
+        metadata = parse_response(response)
+
+        hash.map do |component_id, items|
+          updated_payload = items.merge(
+            created_by: metadata[:created_by],
+            service_id: metadata[:service_id]
+          )
+
+          metadata_api_test_client.create_items(
+            service_id: metadata[:service_id],
+            component_id: component_id,
+            body: updated_payload.to_json,
+            authorisation_headers: authorisation_headers
+          )
+        end
+
+        response = metadata_api_test_client.get_items_for_service(
+          service_id: metadata[:service_id],
+          authorisation_headers: authorisation_headers
+        )
+
+        all_items = parse_response(response)
+
+        expect(all_items[:service_id]).to eq(metadata[:service_id])
+        expect(all_items[:items]).to match_array(expected_response)
       end
     end
 

--- a/spec/integration/metadata_api_test_client.rb
+++ b/spec/integration/metadata_api_test_client.rb
@@ -57,4 +57,21 @@ class MetadataApiTestClient
       headers: headers.merge(authorisation_headers)
     )
   end
+
+  def get_items_for_service(service_id:, authorisation_headers:)
+    self.class.get(
+      "/services/#{service_id}/items/all",
+      headers: headers.merge(authorisation_headers)
+    )
+  end
+
+  def create_items(service_id:, component_id:, body:, authorisation_headers:)
+    self.class.post(
+      "/services/#{service_id}/components/#{component_id}/items/all",
+      {
+        body: body,
+        headers: headers.merge(authorisation_headers)
+      }
+    )
+  end
 end

--- a/spec/requests/create_component_items_spec.rb
+++ b/spec/requests/create_component_items_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe 'POST /services/:id/components/:id/items/all', type: :request do
+  let(:response_body) { JSON.parse(response.body) }
+  let(:service) { create(:service) }
+  let(:component_id) { 'e0fdd04a-b876-4ad5-8bda-2d2f613d7da8' }
+  let(:keys) { %i[service_id items] }
+
+  before do
+    allow_any_instance_of(Fb::Jwt::Auth).to receive(:verify!).and_return(true)
+    post "/services/#{service.id}/components/#{component_id}/items/all", params: params, as: :json
+  end
+
+  let(:items) do
+    {
+      service_id: service.id,
+      created_by: service.created_by,
+      component_id: component_id,
+      data: [{
+        "text": 'foo',
+        "value": 'bar'
+      }]
+    }
+  end
+
+  context 'when valid attributes' do
+    let(:params) { items }
+
+    it 'returns created status' do
+      expect(response.status).to be(201)
+    end
+
+    it 'creates the record' do
+      expect(
+        Items.exists?(service_id: service.id)
+      ).to be_truthy
+    end
+  end
+
+  context 'when invalid attributes' do
+    let(:params) { {} }
+
+    it 'returns unprocessable entity' do
+      expect(response.status).to be(422)
+    end
+  end
+
+  context 'when an attribute is missing' do
+    let(:params) { items.except(:data) }
+
+    it 'returns unprocessable entity' do
+      expect(response.status).to be(422)
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/026Zl7pq/2632-autocomplete-create-post-endpoint-to-retrieve-autocomplete-data-from-metadata-db)
### Create the POST endpoint for autocomplete items
Endpoint: `services/:service_id/components/:component_id/items/all`
This endpoint requires the `component_id` as a param as a service can have many autocomplete components, we need to know which items belong to which component within a service.

If the POST request contains a `component_id` that already exists in the database, it will create a new record with the same `component_id`.

### Validate Items Schema
The `before_action` to validate a schema has been moved out of the `ApplicationController` into it's own class as the `ComponentItemsController` params does not have a 'metadata' key, and hence will fail validation for this reason.
The `validate_items` method has been created to check the appropriate schema is valid.

### Bump presenter gem 2.17.3