### PR TITLE
Change autocomplete endpoint

### DIFF
--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -2,15 +2,15 @@ class ComponentItemsController < ApplicationController
   before_action :validate_items, only: :create
 
   def index
-    render json: ComponentItemsSerialiser.new(service.items, service).attributes, status: :ok
+    render json: ComponentItemsSerialiser.new(service.items, params[:service_id]).attributes, status: :ok
   end
 
   def create
     if new_items.save
-      render(status: :created)
+      render json: { message: 'Created' }, status: :created
     else
       render json: ErrorsSerializer.new(
-        message: service.errors.full_messages
+        message: new_items.errors.full_messages
       ).attributes, status: :unprocessable_entity
     end
   end

--- a/app/serialisers/component_items_serialiser.rb
+++ b/app/serialisers/component_items_serialiser.rb
@@ -1,14 +1,14 @@
 class ComponentItemsSerialiser
-  attr_accessor :items, :service
+  attr_accessor :items, :service_id
 
-  def initialize(items, service)
+  def initialize(items, service_id)
     @items = items
-    @service = service
+    @service_id = service_id
   end
 
   def attributes
     {
-      service_id: service.id,
+      service_id: service_id,
       items: all_items
     }
   end

--- a/spec/requests/create_component_items_spec.rb
+++ b/spec/requests/create_component_items_spec.rb
@@ -49,5 +49,11 @@ RSpec.describe 'POST /services/:id/components/:id/items/all', type: :request do
     it 'returns unprocessable entity' do
       expect(response.status).to be(422)
     end
+
+    it 'returns error messages' do
+      expect(JSON.parse(response.body)['message']).to eq(
+        ["Data can't be blank"]
+      )
+    end
   end
 end

--- a/spec/serialisers/component_items_serialiser_spec.rb
+++ b/spec/serialisers/component_items_serialiser_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ComponentItemsSerialiser do
   let(:service) { Service.create!(service_params) }
   let(:items_params_one) do
     {
-      service: service,
+      service_id: service.id,
       component_id: '2f132e68-0e3b-48ed-a5ad-61f21fcb3d22',
       created_by: '0009212e-5925-4d28-a3f7-725774e2ac6b',
       data: [
@@ -33,7 +33,7 @@ RSpec.describe ComponentItemsSerialiser do
   end
   let(:items_params_two) do
     {
-      service: service,
+      service_id: service.id,
       component_id: 'a572cfd2-9ab5-447c-8e22-c852609cbf6d',
       created_by: '0009212e-5925-4d28-a3f7-725774e2ac6b',
       data: [
@@ -48,12 +48,13 @@ RSpec.describe ComponentItemsSerialiser do
       ]
     }
   end
+
   context 'items' do
     it 'items should be valid against the schema' do
       Items.create!(items_params_one)
       Items.create!(items_params_two)
       all_items = Items.where(service_id: service.id)
-      serialiser = ComponentItemsSerialiser.new(all_items, service)
+      serialiser = ComponentItemsSerialiser.new(all_items, service.id)
       expect(serialiser.attributes).to eq(
         {
           service_id: service.id,


### PR DESCRIPTION
- Change the response from the POST endpoint to return a JSON body and status.
- Change the argument in the ComponentItemsSerialiser from the service to the service id.