### PR TITLE
Add GET endpoint to get items associated with a component

### DIFF
--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -5,6 +5,16 @@ class ComponentItemsController < ApplicationController
     render json: ComponentItemsSerialiser.new(service.items, params[:service_id]).attributes, status: :ok
   end
 
+  def show
+    if component_items.any?
+      render json: ComponentItemsSerialiser.new(component_items, params[:service_id]).attributes, status: :ok
+    else
+      render json: ErrorsSerializer.new(
+        message: "Component with id: #{params[:component_id]} has no items"
+      ).attributes, status: :not_found
+    end
+  end
+
   def create
     if new_items.save
       render json: { message: 'Created' }, status: :created
@@ -32,5 +42,9 @@ class ComponentItemsController < ApplicationController
       json: ErrorsSerializer.new(message: e.message).attributes,
       status: :unprocessable_entity
     )
+  end
+
+  def component_items
+    Items.where(service_id: params[:service_id], component_id: params[:component_id])
   end
 end

--- a/app/serialisers/component_items_serialiser.rb
+++ b/app/serialisers/component_items_serialiser.rb
@@ -1,5 +1,5 @@
 class ComponentItemsSerialiser
-  attr_accessor :items, :service_id
+  attr_reader :items, :service_id
 
   def initialize(items, service_id)
     @items = items

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,8 @@ Rails.application.routes.draw do
     end
 
     get '/items/all', as: :items, to: 'component_items#index'
-    post 'components/:component_id/items/all', to: 'component_items#create'
+    get '/components/:component_id/items', to: 'component_items#show'
+    post '/components/:component_id/items/all', to: 'component_items#create'
   end
 
   match '*unmatched', to: 'application#not_found', via: :all

--- a/spec/integration/endpoints_spec.rb
+++ b/spec/integration/endpoints_spec.rb
@@ -219,6 +219,94 @@ RSpec.describe 'API integration tests' do
       end
     end
 
+    context 'getting all items for a component' do
+      let(:component_id_two) { '1c6bef50-d2a5-4c59-b4f9-8bb4667b3647' }
+      let(:items_two) do
+        {
+          component_id: component_id_two,
+          data: [
+            {
+              "text": 'cat',
+              "value": '100'
+            },
+            {
+              "text": 'dog',
+              "value": '200'
+            }
+          ]
+        }
+      end
+      let(:expected_response) do
+        {
+          "b27cb47a-95cf-44d8-be2b-75b2411c2188": [
+            { text: 'foo', value: 'bar' },
+            { text: '123', value: 'abc' },
+            { text: 'qweq', value: '0976' }
+          ]
+        }
+      end
+      let(:hash) do
+        Hash[
+          component_id_one => items_one,
+          component_id_two => items_two
+        ]
+      end
+
+      context 'when component has items' do
+        it 'it should return all the items for that component' do
+          response = metadata_api_test_client.create_service(
+            body: request_body,
+            authorisation_headers: authorisation_headers
+          )
+          metadata = parse_response(response)
+
+          hash.map do |component_id, items|
+            updated_payload = items.merge(
+              created_by: metadata[:created_by],
+              service_id: metadata[:service_id]
+            )
+
+            metadata_api_test_client.create_items(
+              service_id: metadata[:service_id],
+              component_id: component_id,
+              body: updated_payload.to_json,
+              authorisation_headers: authorisation_headers
+            )
+          end
+
+          response = metadata_api_test_client.get_items_for_component(
+            service_id: metadata[:service_id],
+            component_id: component_id_one,
+            authorisation_headers: authorisation_headers
+          )
+
+          all_items = parse_response(response)
+
+          expect(all_items[:service_id]).to eq(metadata[:service_id])
+          expect(all_items[:items]).to match_array(expected_response)
+        end
+      end
+
+      context 'when component does not have items' do
+        it 'returns a 404' do
+          response = metadata_api_test_client.create_service(
+            body: request_body,
+            authorisation_headers: authorisation_headers
+          )
+          metadata = parse_response(response)
+
+          response = metadata_api_test_client.get_items_for_component(
+            service_id: metadata[:service_id],
+            component_id: '123456789',
+            authorisation_headers: authorisation_headers
+          )
+
+          expect(response.code).to be(404)
+          expect(response['message']).to eq(['Component with id: 123456789 has no items'])
+        end
+      end
+    end
+
     context 'getting all versions of a service' do
       it 'returns all the versions for that service' do
         response = metadata_api_test_client.create_service(

--- a/spec/integration/metadata_api_test_client.rb
+++ b/spec/integration/metadata_api_test_client.rb
@@ -74,4 +74,13 @@ class MetadataApiTestClient
       }
     )
   end
+
+  def get_items_for_component(service_id:, component_id:, authorisation_headers:)
+    self.class.get(
+      "/services/#{service_id}/components/#{component_id}/items",
+      {
+        headers: headers.merge(authorisation_headers)
+      }
+    )
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/DzJhe3B3/2712-autocomplete-check-already-existing-items-on-upload-modal)

To minimise the amount of data that is returned to the Editor, we decided to create a new endpoint that returns items associated with one component: `services/:service_id/components/:component_id/items`
This is something we need to cater for in the Editor, to notify users as to whether they will be overwriting their already existing items or whether their autocomplete component does not have any associated items.

On success, the endpoint returns a `200` and the items associated with the component.
On failure, the endpoint returns a `404` and an error message.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>