### PR TITLE
Continuous Deployment to Live

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,15 +198,6 @@ workflows:
       - editor_acceptance_tests_eks:
           requires:
             - deploy_to_test_eks
-      - slack/approval-notification:
-          message: ":portalorangeparrot:  Deployment to Live pending approval  :portalblueparrot:"
-          include_job_number_field: false
-          requires:
-            - editor_acceptance_tests_eks
-      - confirm_live_deploy:
-          type: approval
-          requires:
-            - editor_acceptance_tests_eks
       - deploy_to_live_eks:
           requires:
-            - confirm_live_deploy
+            - editor_acceptance_tests_eks


### PR DESCRIPTION
We are removing the manual gate to the Live environment as we are moving
to using continuous deployment