### PR TITLE
Add filtering services by name to services_controller#index

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -2,7 +2,13 @@ class ServicesController < MetadataController
   SERVICE_EXISTS = 'Name has already been taken'.freeze
 
   def index
-    services = Service.order(name: :asc).page(page).per(per_page)
+    services = Service.order(name: :asc)
+
+    if name_query.present?
+      services = services.where(Service.arel_table[:name].matches("%#{Service.sanitize_sql_like(name_query)}%"))
+    end
+
+    services = services.page(page).per(per_page)
 
     render json: ServicesSerializer.new(services, total_services: true).attributes
   end
@@ -43,5 +49,9 @@ class ServicesController < MetadataController
 
   def per_page
     params[:per_page] || 20
+  end
+
+  def name_query
+    params[:name_query] || ''
   end
 end

--- a/spec/requests/get_services_spec.rb
+++ b/spec/requests/get_services_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'GET /services' do
   let!(:service_three) do
     create(
       :service,
-      name: 'Service 3',
+      name: 'Ze Numero 3',
       created_by: 'greedo',
       metadata: [build(:metadata, created_by: 'greedo')]
     )
@@ -111,6 +111,35 @@ RSpec.describe 'GET /services' do
           ]
         )
       end
+    end
+  end
+
+  context 'when filtering by name' do
+    let(:name_query) { 'nume' }
+
+    before do
+      allow_any_instance_of(Fb::Jwt::Auth).to receive(:verify!).and_return(true)
+      get "/services?name_query=#{name_query}", as: :json
+    end
+
+    it 'returns success response' do
+      expect(response.status).to eq(200)
+    end
+
+    it 'returns the total services' do
+      expect(response_body['total_services']).to be(3)
+    end
+
+    it 'returns services matching the name query' do
+      expect(response_body['services']).to match_array(
+        [
+          {
+            'service_name' => service_three.name,
+            'service_id' => service_three.id
+          }
+
+        ]
+      )
     end
   end
 end


### PR DESCRIPTION
Adds the ability for the services#index to handle a name_query paramenter to filter the returned services by name.