### PR TITLE
Make pagination work correctly with a search query

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -6,11 +6,12 @@ class ServicesController < MetadataController
 
     if name_query.present?
       services = services.where(Service.arel_table[:name].matches("%#{Service.sanitize_sql_like(name_query)}%"))
+      query_results_count = services.count
     end
 
     services = services.page(page).per(per_page)
 
-    render json: ServicesSerializer.new(services, total_services: true).attributes
+    render json: ServicesSerializer.new(services, total_services: query_results_count || true).attributes
   end
 
   def create

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -6,12 +6,12 @@ class ServicesController < MetadataController
 
     if name_query.present?
       services = services.where(Service.arel_table[:name].matches("%#{Service.sanitize_sql_like(name_query)}%"))
-      query_results_count = services.count
     end
 
+    total_services = services.count
     services = services.page(page).per(per_page)
 
-    render json: ServicesSerializer.new(services, total_services: query_results_count || true).attributes
+    render json: ServicesSerializer.new(services, total_services: total_services).attributes
   end
 
   def create

--- a/app/serialisers/services_serializer.rb
+++ b/app/serialisers/services_serializer.rb
@@ -16,7 +16,7 @@ class ServicesSerializer
     response = { services: all_services }
 
     response.tap do
-      response[:total_services] = Service.count if total_services.present?
+      response[:total_services] = (total_services.is_a?(Integer) ? total_services : Service.count) if total_services.present?
     end
   end
 end

--- a/app/serialisers/services_serializer.rb
+++ b/app/serialisers/services_serializer.rb
@@ -1,7 +1,7 @@
 class ServicesSerializer
   attr_reader :services, :total_services
 
-  def initialize(services, total_services: false)
+  def initialize(services, total_services: nil)
     @services = services
     @total_services = total_services
   end
@@ -16,7 +16,7 @@ class ServicesSerializer
     response = { services: all_services }
 
     response.tap do
-      response[:total_services] = (total_services.is_a?(Integer) ? total_services : Service.count) if total_services.present?
+      response[:total_services] = total_services if total_services.present?
     end
   end
 end

--- a/spec/requests/get_services_spec.rb
+++ b/spec/requests/get_services_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'GET /services' do
     end
 
     it 'returns the total services' do
-      expect(response_body['total_services']).to be(3)
+      expect(response_body['total_services']).to be(1)
     end
 
     it 'returns services matching the name query' do


### PR DESCRIPTION
Not sure about the code for this change, but in order for pagination to work properly when we have a search, we need total_services to actually reflect the total number of results for the search query not the total number of all services.