### PR TITLE
Return latest autocomplete items for each component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :development, :test do
   gem 'httparty'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     thor (1.2.1)
+    timecop (0.9.5)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     tzinfo-data (1.2022.3)
@@ -288,6 +289,7 @@ DEPENDENCIES
   sentry-ruby (~> 5.4.1)
   spring
   spring-watcher-listen (~> 2.0.0)
+  timecop
   tzinfo-data
 
 RUBY VERSION

--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -2,7 +2,7 @@ class ComponentItemsController < ApplicationController
   before_action :validate_items, only: :create
 
   def index
-    render json: ComponentItemsSerialiser.new(service.items, params[:service_id]).attributes, status: :ok
+    render json: ComponentItemsSerialiser.new(existing_component_items, params[:service_id]).attributes, status: :ok
   end
 
   def show
@@ -49,5 +49,15 @@ class ComponentItemsController < ApplicationController
 
   def component_items
     Items.where(service_id: params[:service_id], component_id: params[:component_id])
+  end
+
+  def existing_component_items
+    existing_component_uuids.map do |uuid|
+      Items.where(service: service, component_id: uuid).latest_version
+    end
+  end
+
+  def existing_component_uuids
+    service.latest_metadata.autocomplete_uuids
   end
 end

--- a/app/models/items.rb
+++ b/app/models/items.rb
@@ -1,4 +1,7 @@
 class Items < ApplicationRecord
   belongs_to :service
   validates :data, :created_by, :component_id, :service_id, presence: true
+
+  scope :latest_version, -> { ordered.first }
+  scope :ordered, -> { order(created_at: :desc) }
 end

--- a/app/models/metadata.rb
+++ b/app/models/metadata.rb
@@ -6,4 +6,18 @@ class Metadata < ApplicationRecord
   scope :latest_version, -> { ordered.first }
   scope :ordered, -> { order(created_at: :desc) }
   scope :all_versions, -> { select(:id, :created_at) }
+
+  def autocomplete_uuids
+    autocomplete_components.map { |component| component['_uuid'] }
+  end
+
+  private
+
+  def all_components
+    data['pages'].map { |page| page['components'] }.compact
+  end
+
+  def autocomplete_components
+    all_components.flatten.select { |c| c['_type'] == 'autocomplete' }
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -11,9 +11,16 @@ FactoryBot.define do
   end
 
   factory :items do
-    data { [] }
     created_by { 'Fay' }
     service_id { SecureRandom.uuid }
     component_id { SecureRandom.uuid }
+    data do
+      [
+        { 'text' => 'jack', 'value' => 'bauer' },
+        { 'text' => 'james', 'value' => 'bond' },
+        { 'text' => 'jason', 'value' => 'bourne' },
+        { 'text' => 'jack', 'value' => 'burton' }
+      ]
+    end
   end
 end

--- a/spec/fixtures/load_testing/service.json
+++ b/spec/fixtures/load_testing/service.json
@@ -14,10 +14,6 @@
       "body": "You cannot use this form to complain about:\r\n\r\n* the result of a case\r\n* a judge, magistrate, coroner or member of a tribunal\r\n\r\nThis online form is also available in [Welsh (Cymraeg)](https://complain-about-a-court-or-tribunal.form.service.justice.gov.uk/cy).",
       "heading": "Complain about a court or tribunal",
       "lede": "Your complaint will not affect your case.",
-      "steps": [
-        "page.name",
-        "page.email-address"
-      ],
       "url": "/"
     }
   ],

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -1,2 +1,84 @@
 RSpec.describe Metadata, type: :model do
+  subject(:metadata) do
+    Metadata.new(
+      service: service,
+      locale: 'en',
+      data: data,
+      created_by: 'Maverick'
+    )
+  end
+  let(:data) do
+    {
+      configuration: {},
+      pages: [
+        { "_id": 'page.start' },
+        {
+          "_id": 'page.countries',
+          "components": [
+            {
+              "_type": 'autocomplete',
+              "_uuid": component_id_one
+            }
+          ]
+        },
+        {
+          "_id": 'page.names',
+          "components": [
+            {
+              "_type": 'text',
+              "_uuid": SecureRandom.uuid
+            }
+          ]
+        },
+        {
+          "_id": 'page.cakes',
+          "components": [
+            {
+              "_type": 'autocomplete',
+              "_uuid": component_id_two
+            }
+          ]
+        },
+        { "_id": 'page.checkanswers' }
+      ]
+    }
+  end
+  let(:component_id_one) { SecureRandom.uuid }
+  let(:component_id_two) { SecureRandom.uuid }
+
+  describe '#autocomplete_uuids' do
+    let(:service) { create(:service) }
+
+    context 'when there are autocomplete components' do
+      let(:expected_uuids) { [component_id_one, component_id_two] }
+
+      before do
+        create(:metadata, service: service, data: data)
+        create(
+          :items,
+          service: service,
+          component_id: component_id_one,
+          service_id: service.id
+        )
+        create(
+          :items,
+          service: service,
+          component_id: component_id_two,
+          service_id: service.id
+        )
+      end
+
+      it 'returns uuids of autocomplete items in a service' do
+        expect(metadata.autocomplete_uuids).to eq(expected_uuids)
+      end
+    end
+
+    context 'when there are no autocomplete components' do
+      let(:metadata) { create(:metadata, service: service) }
+
+      it 'returns empty' do
+        expect(metadata.autocomplete_uuids).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/fdaONyWG/2863-autocomplete-metadata-api-returns-all-uploaded-items-for-a-service-instead-of-only-those-necessary)

Previously we were returning _all_ of the autocomplete items for each
component when in fact we only want the latest one.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>