### PR TITLE
Return autocomplete item ids for a service

### DIFF
--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -58,6 +58,6 @@ class ComponentItemsController < ApplicationController
   end
 
   def existing_component_uuids
-    service.latest_metadata.autocomplete_uuids
+    service.latest_metadata.autocomplete_component_uuids
   end
 end

--- a/app/serialisers/component_items_serialiser.rb
+++ b/app/serialisers/component_items_serialiser.rb
@@ -9,6 +9,7 @@ class ComponentItemsSerialiser
   def attributes
     {
       service_id: service_id,
+      autocomplete_ids: items.map(&:id),
       items: all_items
     }
   end

--- a/spec/fixtures/autocomplete.json
+++ b/spec/fixtures/autocomplete.json
@@ -1,0 +1,266 @@
+{
+  "_id": "service.base",
+  "flow": {
+    "00a8a9ff-9aa5-4993-b336-3b16fe39645b": {
+      "next": {
+        "default": "60b4ad74-edb6-48a2-90e1-467499cc18d4"
+      },
+      "_type": "flow.page"
+    },
+    "2d8a9fc5-78f2-4326-83f2-55092cf76016": {
+      "next": {
+        "default": "785ccfae-50d9-46e5-ba54-caf80c957089"
+      },
+      "_type": "flow.page"
+    },
+    "4d9d00f1-905d-4022-a392-b9d96bb9440b": {
+      "next": {
+        "default": "2d8a9fc5-78f2-4326-83f2-55092cf76016"
+      },
+      "_type": "flow.page"
+    },
+    "60b4ad74-edb6-48a2-90e1-467499cc18d4": {
+      "next": {
+        "default": "4d9d00f1-905d-4022-a392-b9d96bb9440b"
+      },
+      "_type": "flow.page"
+    },
+    "785ccfae-50d9-46e5-ba54-caf80c957089": {
+      "next": {
+        "default": ""
+      },
+      "_type": "flow.page"
+    },
+    "8a6b76c5-f963-42ec-94cc-86c15ce656e4": {
+      "next": {
+        "default": "2d8a9fc5-78f2-4326-83f2-55092cf76016"
+      },
+      "_type": "flow.page"
+    },
+    "b854ca26-eed2-4a1e-85c2-733538247c20": {
+      "next": {
+        "default": "00a8a9ff-9aa5-4993-b336-3b16fe39645b"
+      },
+      "_type": "flow.page"
+    }
+  },
+  "_type": "service.base",
+  "pages": [
+    {
+      "_id": "page.start",
+      "url": "/",
+      "body": "Use this service to:\r\n\r\n* do something\r\n* update your name, address or other details\r\n* do something else\r\n\r\nRegistering takes around 5 minutes.",
+      "_type": "page.start",
+      "_uuid": "b854ca26-eed2-4a1e-85c2-733538247c20",
+      "heading": "Service name goes here",
+      "before_you_start": "###Before you start\r\nYou can also register by post.\r\n\r\nThe online service is also available in Welsh (Cymraeg).\r\n\r\nYou cannot register for this service if you’re in the UK illegally."
+    },
+    {
+      "_id": "page.cakes",
+      "url": "cakes",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "00a8a9ff-9aa5-4993-b336-3b16fe39645b",
+      "heading": "",
+      "components": [
+        {
+          "_id": "cakes_autocomplete_1",
+          "hint": "",
+          "name": "cakes_autocomplete_1",
+          "_type": "autocomplete",
+          "_uuid": "5066aeab-342f-45d4-b01c-bd27bc92b77a",
+          "label": "Cakes",
+          "errors": {
+          },
+          "legend": "Question",
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "autocomplete": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.biscuits",
+      "url": "biscuits",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "60b4ad74-edb6-48a2-90e1-467499cc18d4",
+      "heading": "",
+      "components": [
+        {
+          "_id": "biscuits_autocomplete_1",
+          "hint": "",
+          "name": "biscuits_autocomplete_1",
+          "_type": "autocomplete",
+          "_uuid": "93f6108b-7131-4c82-96de-e74b9edad9fa",
+          "label": "Biscuits",
+          "errors": {
+          },
+          "legend": "Question",
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "autocomplete": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.ice-cream",
+      "url": "ice-cream",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "4d9d00f1-905d-4022-a392-b9d96bb9440b",
+      "heading": "",
+      "components": [
+        {
+          "_id": "ice-cream_autocomplete_1",
+          "hint": "",
+          "name": "ice-cream_autocomplete_1",
+          "_type": "autocomplete",
+          "_uuid": "a08c5fad-ac07-4721-9df1-f0cddb5d290c",
+          "label": "Ice Creams",
+          "errors": {
+          },
+          "legend": "Question",
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "autocomplete": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.pizzas",
+      "url": "pizzas",
+      "body": "Body section",
+      "lede": "",
+      "_type": "page.singlequestion",
+      "_uuid": "8a6b76c5-f963-42ec-94cc-86c15ce656e4",
+      "heading": "",
+      "components": [
+        {
+          "_id": "pizzas_autocomplete_1",
+          "hint": "",
+          "name": "pizzas_autocomplete_1",
+          "_type": "autocomplete",
+          "_uuid": "5eab9b94-3db8-4e80-b4aa-0583ee6a8c8a",
+          "label": "Pizzas",
+          "errors": {
+          },
+          "legend": "Question",
+          "collection": "components",
+          "validation": {
+            "required": true,
+            "autocomplete": true
+          }
+        }
+      ],
+      "section_heading": ""
+    },
+    {
+      "_id": "page.checkanswers",
+      "url": "check-answers",
+      "_type": "page.checkanswers",
+      "_uuid": "2d8a9fc5-78f2-4326-83f2-55092cf76016",
+      "heading": "Check your answers",
+      "send_body": "By submitting this application you confirm that, to the best of your knowledge, the details you are providing are correct.",
+      "components": [
+
+      ],
+      "send_heading": "Now send your application",
+      "extra_components": [
+
+      ]
+    },
+    {
+      "_id": "page.confirmation",
+      "url": "form-sent",
+      "_type": "page.confirmation",
+      "_uuid": "785ccfae-50d9-46e5-ba54-caf80c957089",
+      "heading": "Application complete",
+      "components": [
+
+      ]
+    }
+  ],
+  "locale": "en",
+  "created_at": "2022-08-31T14:55:17Z",
+  "created_by": "b7eff904-9fec-4c48-b6ac-4572b490a040",
+  "service_id": "d17f5ccb-f30b-48a1-9931-ad7b41e6aac7",
+  "version_id": "9f86edcd-6cb1-4b1f-bfb6-9bb9bcd347a3",
+  "service_name": "123autocomplete-test",
+  "configuration": {
+    "meta": {
+      "_id": "config.meta",
+      "_type": "config.meta",
+      "items": [
+        {
+          "_id": "config.meta--link",
+          "href": "/cookies",
+          "text": "Cookies",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--2",
+          "href": "/privacy",
+          "text": "Privacy",
+          "_type": "link"
+        },
+        {
+          "_id": "config.meta--link--3",
+          "href": "/accessibility",
+          "text": "Accessibility",
+          "_type": "link"
+        }
+      ]
+    },
+    "service": {
+      "_id": "config.service",
+      "_type": "config.service"
+    }
+  },
+  "standalone_pages": [
+    {
+      "_id": "page.cookies",
+      "url": "cookies",
+      "body": "cookies body",
+      "_type": "page.standalone",
+      "_uuid": "5bdb4b9d-8855-4ab1-a2c4-31a68b420708",
+      "heading": "Cookies",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.privacy",
+      "url": "privacy",
+      "body": "privacy body",
+      "_type": "page.standalone",
+      "_uuid": "8e458163-a84e-4dba-9dac-de89017bab02",
+      "heading": "Privacy notice",
+      "components": [
+
+      ]
+    },
+    {
+      "_id": "page.accessibility",
+      "url": "accessibility",
+      "body": "accessibility body",
+      "_type": "page.standalone",
+      "_uuid": "cf7c5876-eb47-44f5-b426-c15bc2769680",
+      "heading": "Accessibility statement",
+      "components": [
+      ]
+    }
+  ]
+}

--- a/spec/models/metadata_spec.rb
+++ b/spec/models/metadata_spec.rb
@@ -3,57 +3,33 @@ RSpec.describe Metadata, type: :model do
     Metadata.new(
       service: service,
       locale: 'en',
-      data: data,
+      data: service_metadata,
       created_by: 'Maverick'
     )
   end
-  let(:data) do
-    {
-      configuration: {},
-      pages: [
-        { "_id": 'page.start' },
-        {
-          "_id": 'page.countries',
-          "components": [
-            {
-              "_type": 'autocomplete',
-              "_uuid": component_id_one
-            }
-          ]
-        },
-        {
-          "_id": 'page.names',
-          "components": [
-            {
-              "_type": 'text',
-              "_uuid": SecureRandom.uuid
-            }
-          ]
-        },
-        {
-          "_id": 'page.cakes',
-          "components": [
-            {
-              "_type": 'autocomplete',
-              "_uuid": component_id_two
-            }
-          ]
-        },
-        { "_id": 'page.checkanswers' }
-      ]
-    }
+  let(:service_metadata) do
+    JSON.parse(File.read(Rails.root.join('spec', 'fixtures', 'autocomplete.json')))
   end
-  let(:component_id_one) { SecureRandom.uuid }
-  let(:component_id_two) { SecureRandom.uuid }
+  let(:autocomplete_service) { MetadataPresenter::Service.new(service_metadata) }
+  let(:service_id) { service_metadata['service_id'] }
+  let(:component_id_one) do
+    autocomplete_service.find_page_by_url('cakes').components.first.uuid
+  end
+  let(:component_id_two) do
+    autocomplete_service.find_page_by_url('biscuits').components.first.uuid
+  end
+  let(:component_id_three) do
+    autocomplete_service.find_page_by_url('ice-cream').components.first.uuid
+  end
 
-  describe '#autocomplete_uuids' do
-    let(:service) { create(:service) }
+  describe '#autocomplete_component_uuids' do
+    let(:service) { create(:service, id: service_id) }
 
     context 'when there are autocomplete components' do
-      let(:expected_uuids) { [component_id_one, component_id_two] }
+      let(:expected_uuids) { [component_id_one, component_id_two, component_id_three] }
 
       before do
-        create(:metadata, service: service, data: data)
+        create(:metadata, service: service, data: service_metadata)
         create(
           :items,
           service: service,
@@ -68,16 +44,19 @@ RSpec.describe Metadata, type: :model do
         )
       end
 
-      it 'returns uuids of autocomplete items in a service' do
-        expect(metadata.autocomplete_uuids).to eq(expected_uuids)
+      it 'returns uuids of autocomplete components in a service' do
+        expect(metadata.autocomplete_component_uuids).to eq(expected_uuids)
       end
     end
 
     context 'when there are no autocomplete components' do
-      let(:metadata) { create(:metadata, service: service) }
+      let(:service_metadata) do
+        JSON.parse(File.read(fixtures_directory.join('branching.json')))
+      end
+      let(:metadata) { create(:metadata, service: service, data: service_metadata) }
 
       it 'returns empty' do
-        expect(metadata.autocomplete_uuids).to be_empty
+        expect(metadata.autocomplete_component_uuids).to be_empty
       end
     end
   end

--- a/spec/serialisers/component_items_serialiser_spec.rb
+++ b/spec/serialisers/component_items_serialiser_spec.rb
@@ -50,14 +50,16 @@ RSpec.describe ComponentItemsSerialiser do
   end
 
   context 'items' do
+    let!(:items_one) { Items.create(items_params_one) }
+    let!(:items_two) { Items.create(items_params_two) }
+
     it 'items should be valid against the schema' do
-      Items.create!(items_params_one)
-      Items.create!(items_params_two)
       all_items = Items.where(service_id: service.id)
       serialiser = ComponentItemsSerialiser.new(all_items, service.id)
       expect(serialiser.attributes).to eq(
         {
           service_id: service.id,
+          autocomplete_ids: [items_one.id, items_two.id],
           items: {
             '2f132e68-0e3b-48ed-a5ad-61f21fcb3d22' => [
               { 'text' => 'ragdoll', 'value' => '1' },


### PR DESCRIPTION
[Trello](https://trello.com/c/AQN8Fcmj/2845-autocomplete-add-versionid-column-in-autocomplete-db)

### Return autocomplete item ids for a service
The Editor will need to log which autocomplete items were used during publishing, so we will need to return those ids and the items.

### Cater for detached autocomplete components
Prior to this change we would return all the items associated with an autocomplete component, this included items that were associated with a detached component. We do not want to return any unnecessary items.

This change ensures we only get items that are associated with components in the main flow of a form. Since we now rely on the grid and flow objects, we need to ensure our test metadata accurately reflects the metadata in a live form, hence
we have decided to use a fixture. The fixture contains 4 autocomplete components, one of which is detached