### PR TITLE
Cater for for when there are no autocomplete items in a service

### DIFF
--- a/app/controllers/component_items_controller.rb
+++ b/app/controllers/component_items_controller.rb
@@ -52,9 +52,9 @@ class ComponentItemsController < ApplicationController
   end
 
   def existing_component_items
-    existing_component_uuids.map do |uuid|
+    existing_component_uuids.map { |uuid|
       Items.where(service: service, component_id: uuid).latest_version
-    end
+    }.flatten
   end
 
   def existing_component_uuids

--- a/spec/requests/get_component_items_spec.rb
+++ b/spec/requests/get_component_items_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe 'GET /services/:service_id/items/all' do
               '_uuid': component_id_two
             }
           ]
+        },
+        {
+          'components': [
+            {
+              '_type': 'autocomplete',
+              '_uuid': SecureRandom.uuid # page with no uploaded items
+            }
+          ]
         }
       ]
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/fdaONyWG/2863-autocomplete-metadata-api-returns-all-uploaded-items-for-a-service-instead-of-only-those-necessary)
Currently, when there are no items found on a service it returns an empty ActiveRecord Relation. We only want a single level array to be returned, flattening removes any empty relations.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>