### PR TITLE
Test services cron update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
       PGPASSWORD: password
       PGUSER: postgres
       RAILS_ENV: test
-    parallelism: 5
+    parallelism: 4
     steps:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver

--- a/deploy-eks/fb-metadata-api-chart/templates/remove_test_services.yaml
+++ b/deploy-eks/fb-metadata-api-chart/templates/remove_test_services.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.environmentName "test" }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -50,3 +51,4 @@ spec:
               - name: PLATFORM_ENV
                 value: {{ .Values.environmentName }}
           restartPolicy: Never
+{{- end }}


### PR DESCRIPTION
- Reduce acceptance tests parallelism to 4 to see if it makes the tests less brittle
- Remove Docker version from circleci config
- Only apply the remove test services cronjob in test