### PR TITLE
Update readiness endpoint

### DIFF
--- a/app/controllers/health_controller.rb
+++ b/app/controllers/health_controller.rb
@@ -4,8 +4,6 @@ class HealthController < ActionController::API
   end
 
   def readiness
-    if ActiveRecord::Base.connection && ActiveRecord::Base.connected?
-      render plain: 'ready'
-    end
+    render plain: 'ready'
   end
 end


### PR DESCRIPTION
Remove the check for the DB connection. Rails does this on startup anyway.