### PR TITLE
Add resource request limits config

### DIFF
--- a/deploy-eks/fb-metadata-api-chart/templates/deployment.yaml
+++ b/deploy-eks/fb-metadata-api-chart/templates/deployment.yaml
@@ -1,5 +1,4 @@
 ---
-# api front-end
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,6 +25,12 @@ spec:
       containers:
       - name: "fb-metadata-api-{{ .Values.environmentName }}"
         image: "754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-metadata-api:{{ .Values.circleSha1 }}"
+        {{- if ((.Values.resources).requests) }}
+        resources:
+          requests:
+            memory: {{ .Values.resources.requests.memory }}
+            cpu: {{ .Values.resources.requests.cpu }}
+        {{- end }}
         volumeMounts:
         - mountPath: /tmp
           name: tmp-files


### PR DESCRIPTION
This adds the resource request limits configuration. The fb-metadata-api-deploy repo has it for Test and Live. If it is not there then do not set it at all.