### PR TITLE
Use updated Github RSA SSH key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
       RAILS_ENV: test
     parallelism: 4
     steps:
+      - checkout
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - run:


### PR DESCRIPTION
### Add 'checkout' step to CircleCI config
Github have recently rotated their RSA SSH host key. As a result, the public key is no longer up to date in the known_host file.

The 'checkout' step automatically adds the required authenticity keys for interacting with Github. Adding this job allows the acceptance test and smoke tests steps to interact with Github.