### PR TITLE
Add GOVUK env vars for GovUK Publishing component

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,10 @@ EXPOSE $APP_PORT
 
 USER ${UID}
 
+# Govuk Publishing Components gem requires these env vars to be set, however we
+# do not actually need to use them.
+ENV GOVUK_APP_DOMAIN ''
+ENV GOVUK_WEBSITE_ROOT ''
+
 ARG RAILS_ENV=production
 CMD bundle exec rake db:migrate:ignore_concurrent && bundle exec rails s -e ${RAILS_ENV} -p ${APP_PORT} --binding=0.0.0.0


### PR DESCRIPTION
Add GOVUK env vars for GovUK Publishing component. These env vars as they are required, but we do not use them.

### CircleCI run
https://app.circleci.com/pipelines/github/ministryofjustice/fb-metadata-api/2083/workflows/d4df620c-3bb6-4244-9881-ac2da4a42c04