### PR TITLE
Bump to presenter 3.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '3.1.3'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'fb-jwt-auth', '~> 0.10.0'
 gem 'kaminari'
-gem 'metadata_presenter', '~> 3.2'
+gem 'metadata_presenter', '~> 3.2.1'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'prometheus-client', '~> 2.1.0'
 gem 'puma', '~> 6.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.2)
-    metadata_presenter (3.2.0)
+    metadata_presenter (3.2.1)
       govspeak (~> 7.1)
       govuk_design_system_formbuilder (>= 2.1.5)
       json-schema (= 2.8.1)
@@ -305,7 +305,7 @@ GEM
       opentelemetry-api (~> 1.1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
       opentelemetry-instrumentation-rack (~> 0.21)
-    opentelemetry-instrumentation-graphql (0.26.2)
+    opentelemetry-instrumentation-graphql (0.26.3)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
     opentelemetry-instrumentation-http (0.23.1)
@@ -332,7 +332,7 @@ GEM
       opentelemetry-api (~> 1.0)
       opentelemetry-common (~> 0.19.3)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-pg (0.25.2)
+    opentelemetry-instrumentation-pg (0.25.3)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
     opentelemetry-instrumentation-que (0.6.1)
@@ -452,7 +452,7 @@ GEM
       rack (>= 1.4)
     rexml (3.2.6)
     rinku (2.0.6)
-    rouge (4.1.2)
+    rouge (4.1.3)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -562,7 +562,7 @@ DEPENDENCIES
   fb-jwt-auth (~> 0.10.0)
   httparty
   kaminari
-  metadata_presenter (~> 3.2)
+  metadata_presenter (~> 3.2.1)
   pg (>= 0.18, < 2.0)
   prometheus-client (~> 2.1.0)
   puma (~> 6.3)


### PR DESCRIPTION
This version of the presenter adds logic to evaluate the content conditional components.
This bump should be fine to deploy to production on the metadata api.