### PR TITLE
Deploying metadata api editor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ jobs:
             echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
+            echo 'export CONDITIONAL_CONTENT=disabled' >> $BASH_ENV
             echo 'export CI_MODE=true' >> $BASH_ENV
             source $BASH_ENV
 
@@ -227,6 +228,7 @@ workflows:
             branches:
               only:
                 - main
+                - deploying-metadata-api-editor
       - deploy_to_test_eks:
           context: *context
           requires:
@@ -235,7 +237,7 @@ workflows:
           context: *context
           requires:
             - deploy_to_test_eks
-      - deploy_to_live_eks:
-          context: *context
-          requires:
-            - editor_acceptance_tests_eks
+#      - deploy_to_live_eks:
+#          context: *context
+#          requires:
+#            - editor_acceptance_tests_eks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,6 @@ workflows:
             branches:
               only:
                 - main
-                - deploying-metadata-api-editor
       - deploy_to_test_eks:
           context: *context
           requires:
@@ -237,7 +236,7 @@ workflows:
           context: *context
           requires:
             - deploy_to_test_eks
-#      - deploy_to_live_eks:
-#          context: *context
-#          requires:
-#            - editor_acceptance_tests_eks
+      - deploy_to_live_eks:
+          context: *context
+          requires:
+            - editor_acceptance_tests_eks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - run:
           name: Run editor acceptance tests (eks)
           command: |
-            EDITOR_APP=https://fb-editor-test.apps.live.cloud-platform.service.justice.gov.uk
+            EDITOR_APP=https://testable-conditional-component.apps.live.cloud-platform.service.justice.gov.uk
             echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV


### PR DESCRIPTION
In order to release conditional content, we need to merge metadata api prior to the editor change. However the metadata api require to run the editor acceptance tests to be fully deployed to production. We update temporally the deployment pipeline to run the acceptance tests on the testable editor that has the conditional content flags on. When the editor will be merged, we will be reverting this change to run the editor acceptance tests on the main editor branch. 