### PR TITLE
Removing use to testable editor for acceptance tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,11 +173,10 @@ jobs:
       - run:
           name: Run editor acceptance tests (eks)
           command: |
-            EDITOR_APP=https://testable-conditional-component.apps.live.cloud-platform.service.justice.gov.uk
+            EDITOR_APP=https://fb-editor-test.apps.live.cloud-platform.service.justice.gov.uk
             echo 'export ACCEPTANCE_TESTS_EDITOR_APP=$EDITOR_APP' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_USER=$ACCEPTANCE_TESTS_USER' >> $BASH_ENV
             echo 'export ACCEPTANCE_TESTS_PASSWORD=$ACCEPTANCE_TESTS_PASSWORD' >> $BASH_ENV
-            echo 'export CONDITIONAL_CONTENT=disabled' >> $BASH_ENV
             echo 'export CI_MODE=true' >> $BASH_ENV
             source $BASH_ENV
 


### PR DESCRIPTION
This is to revert [#661](https://github.com/ministryofjustice/fb-metadata-api/pull/661) so we test the metadata api against the editor main branch