### PR TITLE
Preliminary work for metadata welsh locale

### DIFF
--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -40,7 +40,14 @@ class VersionsController < MetadataController
     render json: MetadataSerialiser.new(service, metadata).attributes, status: :ok
   end
 
+  private
+
+  # TODO: changing locale on the fly (with query param) is not fully implemented
   def locale
-    @locale ||= params[:locale] || 'en'
+    @locale ||= params[:locale] || supported_locales
+  end
+
+  def supported_locales
+    %w[en cy]
   end
 end


### PR DESCRIPTION
Ticket: https://trello.com/c/Qm8FlI3J

Currently the versions SQL queries are scoped by locale. As we only have English (`en`) locale, this has not been an issue so far (as that is the default), but if we change the locale in the metadata JSON to something else like Welsh (`cy`) then the queries will not return results.

This is a preliminary piece of work needed to start supporting metadata with locales other than `en`, and ensuring the metadata API returns them as usual.

In the future we may decide to support the `locale` query param. For now, as the param is not sent to the API, we default to search both locales, `en` and `cy`.