### PR TITLE
Re-enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,22 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  # Disable version updates, but leave security updates
-  open-pull-requests-limit: 0
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+  - StevenLeighton21
+  - mattempty
+  - danielglen-moj
 
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
-  # Disable version updates, but leave security updates
-  open-pull-requests-limit: 0
+    time: "03:00"
+    timezone: Europe/London
+  open-pull-requests-limit: 10
+  reviewers:
+  - StevenLeighton21
+  - mattempty
+  - danielglen-moj


### PR DESCRIPTION
Re-enable version bump PRs from dependabot 

When we were in active feature development this created noise, now we have transitioned to a support team it may be helpful for keeping on top of version changes.

Revert in case of excessive noise!