### PR TITLE
Pin Chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,8 @@ jobs:
     steps:
       - checkout
       - run: sudo apt-get update
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: 126.0.6478.182
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install


### PR DESCRIPTION
We have to pin the chrome (and therefore chromedriver) version for now so the editor ATs work, as later versions have an interaction with selenium that prevents it from finding the dialog boxes.