### PR TITLE
CDPT-3025: Update chrome version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       - checkout
       - run: sudo apt-get update
       - browser-tools/install-chrome:
-          chrome-version: 126.0.6478.182
+          chrome-version: stable
       - browser-tools/install-chromedriver
       - run:
           name: Check browser tools install


### PR DESCRIPTION
### `editor_acceptance_tests_eks` failing because of missing chrome version

<img width="1201" height="361" alt="Screenshot 2025-09-09 at 11 40 57" src="https://github.com/user-attachments/assets/57e5c1f3-8bb2-4fcb-b74c-820f3cb051ba" />

<img width="1063" height="969" alt="Screenshot 2025-09-09 at 11 41 07" src="https://github.com/user-attachments/assets/64e28f8c-bc75-4e5d-a585-bb27bf2dd85d" />
