### PR TITLE
CDPTKAN-709: Remove 'acceptance_tests_eks' step from circleCI deployment pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,14 +227,10 @@ workflows:
           context: *context
           requires:
             - build_and_push_image
-      - editor_acceptance_tests_eks:
-          context: *context
-          requires:
-            - deploy_to_test_eks
       - deploy_to_live_eks:
           context: *context
           requires:
-            - editor_acceptance_tests_eks
+            - deploy_to_test_eks
           filters:
             branches:
               only:


### PR DESCRIPTION
Temporary disable Acceptance Tests from running in the deploy pipeline.

JIRA: https://dsdmoj.atlassian.net/browse/CDPTKAN-709